### PR TITLE
fix: フロントエンド静的配信 + Dockerマルチステージビルド

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,13 @@
-# Build stage
-FROM node:22-slim AS build
+# Frontend build stage
+FROM node:22-slim AS frontend-build
+WORKDIR /app/frontend
+COPY frontend/package.json frontend/package-lock.json ./
+RUN npm ci
+COPY frontend/ .
+RUN npm run build
+
+# Backend build stage
+FROM node:22-slim AS backend-build
 WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm ci
@@ -13,7 +21,8 @@ WORKDIR /app
 ENV NODE_ENV=production
 COPY package.json package-lock.json ./
 RUN npm ci --omit=dev
-COPY --from=build /app/dist/ dist/
+COPY --from=backend-build /app/dist/ dist/
+COPY --from=frontend-build /app/frontend/dist/ frontend/dist/
 EXPOSE 8080
 USER node
 CMD ["node", "dist/index.js"]

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,6 +1,10 @@
+import path from "path";
+import { fileURLToPath } from "url";
 import express from "express";
 import { casesRouter } from "./routes/cases.js";
 import { supportMenusRouter } from "./routes/support-menus.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const app = express();
 const PORT = parseInt(process.env.PORT ?? "8080", 10);
@@ -15,6 +19,13 @@ app.get("/health", (_req, res) => {
 // API routes
 app.use("/api/cases", casesRouter);
 app.use("/api/support-menus", supportMenusRouter);
+
+// Frontend static files
+const frontendDir = path.join(__dirname, "../frontend/dist");
+app.use(express.static(frontendDir));
+app.get("/{*splat}", (_req, res) => {
+  res.sendFile(path.join(frontendDir, "index.html"));
+});
 
 app.listen(PORT, () => {
   console.log(`Kyugo AI server running on port ${PORT}`);


### PR DESCRIPTION
## Summary
- Express 5でフロントエンド静的ファイル配信（SPA fallback対応）を追加
- Dockerfileをマルチステージビルドに変更（frontend-build → backend-build → production）
- Firestoreの複合インデックス（cases: assignedStaffId + updatedAt）は手動作成済み

## 動作確認
- `/` → index.html (200)
- `/cases/xxx` → SPA fallback (200)
- `/health` → `{"status":"ok"}` (200)
- `/api/support-menus` → 10件取得 (200)

## Test plan
- [x] BE 36テストパス
- [x] FE 49テストパス
- [x] ローカルでフロントエンド配信確認
- [ ] CDデプロイ後にCloud Runで動作確認

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build process with multi-stage architecture for independent frontend and backend compilation.

* **New Features**
  * Added static frontend serving capability from the backend.
  * Implemented Single Page Application routing support for unmatched routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->