### PR TITLE
feat: Googleソーシャルログインに切り替え

### DIFF
--- a/frontend/src/pages/Login.test.tsx
+++ b/frontend/src/pages/Login.test.tsx
@@ -2,85 +2,70 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Login } from "./Login";
-import { signInWithEmailAndPassword } from "firebase/auth";
+import { signInWithPopup } from "firebase/auth";
 
 beforeEach(() => {
-  vi.mocked(signInWithEmailAndPassword).mockReset();
+  vi.mocked(signInWithPopup).mockReset();
 });
 
 describe("Login", () => {
-  it("renders login form fields", () => {
+  it("renders Google login button", () => {
     render(<Login />);
 
     expect(screen.getByText("救護AI")).toBeInTheDocument();
-    expect(screen.getByLabelText("メールアドレス")).toBeInTheDocument();
-    expect(screen.getByLabelText("パスワード")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "ログイン" })).toBeInTheDocument();
+    expect(screen.getByText("福祉相談業務AI支援システム")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Googleアカウントでログイン" })).toBeInTheDocument();
   });
 
-  it("calls signInWithEmailAndPassword on submit", async () => {
-    vi.mocked(signInWithEmailAndPassword).mockResolvedValue({} as never);
+  it("calls signInWithPopup on button click", async () => {
+    vi.mocked(signInWithPopup).mockResolvedValue({} as never);
     const user = userEvent.setup();
 
     render(<Login />);
 
-    await user.type(screen.getByLabelText("メールアドレス"), "staff@example.com");
-    await user.type(screen.getByLabelText("パスワード"), "password123");
-    await user.click(screen.getByRole("button", { name: "ログイン" }));
+    await user.click(screen.getByRole("button", { name: "Googleアカウントでログイン" }));
 
-    expect(signInWithEmailAndPassword).toHaveBeenCalledWith(
-      expect.anything(),
-      "staff@example.com",
-      "password123",
-    );
+    expect(signInWithPopup).toHaveBeenCalledWith(expect.anything(), expect.anything());
   });
 
-  it("shows error on invalid credentials", async () => {
-    vi.mocked(signInWithEmailAndPassword).mockRejectedValue(
-      new Error("Firebase: Error (auth/invalid-credential)."),
-    );
+  it("shows error on login failure", async () => {
+    vi.mocked(signInWithPopup).mockRejectedValue(new Error("Network error"));
     const user = userEvent.setup();
 
     render(<Login />);
 
-    await user.type(screen.getByLabelText("メールアドレス"), "wrong@test.com");
-    await user.type(screen.getByLabelText("パスワード"), "wrongpass");
-    await user.click(screen.getByRole("button", { name: "ログイン" }));
-
-    await vi.waitFor(() => {
-      expect(screen.getByText("メールアドレスまたはパスワードが正しくありません")).toBeInTheDocument();
-    });
-  });
-
-  it("shows generic error on unknown failure", async () => {
-    vi.mocked(signInWithEmailAndPassword).mockRejectedValue(
-      new Error("Network error"),
-    );
-    const user = userEvent.setup();
-
-    render(<Login />);
-
-    await user.type(screen.getByLabelText("メールアドレス"), "test@test.com");
-    await user.type(screen.getByLabelText("パスワード"), "password");
-    await user.click(screen.getByRole("button", { name: "ログイン" }));
+    await user.click(screen.getByRole("button", { name: "Googleアカウントでログイン" }));
 
     await vi.waitFor(() => {
       expect(screen.getByText("ログインに失敗しました")).toBeInTheDocument();
     });
   });
 
-  it("disables inputs and shows loading state while submitting", async () => {
-    vi.mocked(signInWithEmailAndPassword).mockReturnValue(new Promise(() => {}));
+  it("does not show error when popup is closed by user", async () => {
+    vi.mocked(signInWithPopup).mockRejectedValue(
+      new Error("Firebase: Error (auth/popup-closed-by-user)."),
+    );
     const user = userEvent.setup();
 
     render(<Login />);
 
-    await user.type(screen.getByLabelText("メールアドレス"), "test@test.com");
-    await user.type(screen.getByLabelText("パスワード"), "pass");
-    await user.click(screen.getByRole("button", { name: "ログイン" }));
+    await user.click(screen.getByRole("button", { name: "Googleアカウントでログイン" }));
 
-    expect(screen.getByLabelText("メールアドレス")).toBeDisabled();
-    expect(screen.getByLabelText("パスワード")).toBeDisabled();
+    await vi.waitFor(() => {
+      expect(screen.getByRole("button", { name: "Googleアカウントでログイン" })).toBeEnabled();
+    });
+    expect(screen.queryByText("ログインに失敗しました")).not.toBeInTheDocument();
+  });
+
+  it("disables button and shows loading state while signing in", async () => {
+    vi.mocked(signInWithPopup).mockReturnValue(new Promise(() => {}));
+    const user = userEvent.setup();
+
+    render(<Login />);
+
+    await user.click(screen.getByRole("button", { name: "Googleアカウントでログイン" }));
+
     expect(screen.getByText("ログイン中...")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "ログイン中..." })).toBeDisabled();
   });
 });

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,26 +1,25 @@
-import { useState, type FormEvent } from "react";
-import { signInWithEmailAndPassword } from "firebase/auth";
+import { useState } from "react";
+import { signInWithPopup, GoogleAuthProvider } from "firebase/auth";
 import { auth } from "../firebase";
 
+const googleProvider = new GoogleAuthProvider();
+
 export function Login() {
-  const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
 
-  const handleSubmit = async (e: FormEvent) => {
-    e.preventDefault();
+  const handleGoogleLogin = async () => {
     setError("");
     setLoading(true);
     try {
-      await signInWithEmailAndPassword(auth, email, password);
+      await signInWithPopup(auth, googleProvider);
     } catch (err) {
       const message = (err as Error).message;
-      if (message.includes("invalid-credential") || message.includes("wrong-password") || message.includes("user-not-found")) {
-        setError("メールアドレスまたはパスワードが正しくありません");
-      } else {
-        setError("ログインに失敗しました");
+      if (message.includes("popup-closed-by-user")) {
+        setLoading(false);
+        return;
       }
+      setError("ログインに失敗しました");
     } finally {
       setLoading(false);
     }
@@ -33,41 +32,16 @@ export function Login() {
           <h1 className="login-title">救護AI</h1>
           <p className="login-subtitle">福祉相談業務AI支援システム</p>
 
-          <form onSubmit={handleSubmit}>
-            {error && <div className="login-error">{error}</div>}
+          {error && <div className="login-error">{error}</div>}
 
-            <div className="form-group">
-              <label htmlFor="email" className="form-label">メールアドレス</label>
-              <input
-                id="email"
-                type="email"
-                className="form-input"
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                required
-                autoComplete="email"
-                disabled={loading}
-              />
-            </div>
-
-            <div className="form-group">
-              <label htmlFor="password" className="form-label">パスワード</label>
-              <input
-                id="password"
-                type="password"
-                className="form-input"
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                required
-                autoComplete="current-password"
-                disabled={loading}
-              />
-            </div>
-
-            <button type="submit" className="btn btn-primary login-btn" disabled={loading}>
-              {loading ? "ログイン中..." : "ログイン"}
-            </button>
-          </form>
+          <button
+            type="button"
+            className="btn btn-primary login-btn google-login-btn"
+            onClick={handleGoogleLogin}
+            disabled={loading}
+          >
+            {loading ? "ログイン中..." : "Googleアカウントでログイン"}
+          </button>
         </div>
       </div>
     </div>

--- a/frontend/src/test-setup.ts
+++ b/frontend/src/test-setup.ts
@@ -20,5 +20,7 @@ vi.mock("firebase/auth", () => ({
   }),
   signOut: vi.fn().mockResolvedValue(undefined),
   signInWithEmailAndPassword: vi.fn(),
+  signInWithPopup: vi.fn(),
+  GoogleAuthProvider: vi.fn(),
   getAuth: vi.fn(),
 }));


### PR DESCRIPTION
## Summary
- メール/パスワード認証からGoogleソーシャルログイン（`signInWithPopup` + `GoogleAuthProvider`）に変更
- ポップアップをユーザーが閉じた場合はエラー非表示
- テスト5件を新方式に対応、全106件パス（BE: 50, FE: 56）

## Firebase Console設定（マージ後に実施）
1. Googleプロバイダ有効化
2. 認可ドメイン追加: `kyugo-ai-2knyenyska-an.a.run.app`, `localhost`

## Test plan
- [x] Login.test.tsx: Googleログインボタン表示、signInWithPopup呼び出し、エラー表示、popup-closed静音化、ローディング状態
- [x] 既存テスト全件パス（回帰なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)