### PR TITLE
fix: staffIdバグ修正 + ファイルサイズ制限調整

### DIFF
--- a/frontend/src/api.test.ts
+++ b/frontend/src/api.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.unmock("./api");
 import { api } from "./api";
 
 const mockFetch = vi.fn();

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -60,7 +60,16 @@ export interface SupportMenu {
   description: string;
 }
 
+export interface UserInfo {
+  uid: string;
+  email: string;
+  role: "admin" | "staff";
+  staffId: string;
+}
+
 export const api = {
+  getMe: () => request<UserInfo>("/api/me"),
+
   listCases: (staffId: string) =>
     request<Case[]>(`/api/cases?staffId=${encodeURIComponent(staffId)}`),
 

--- a/frontend/src/components/NewCaseModal.test.tsx
+++ b/frontend/src/components/NewCaseModal.test.tsx
@@ -4,12 +4,6 @@ import userEvent from "@testing-library/user-event";
 import { NewCaseModal } from "./NewCaseModal";
 import { TestAuthWrapper } from "../test-utils";
 
-vi.mock("../api", () => ({
-  api: {
-    createCase: vi.fn(),
-  },
-}));
-
 import { api } from "../api";
 
 beforeEach(() => {
@@ -83,7 +77,7 @@ describe("NewCaseModal", () => {
       clientName: "テスト太郎",
       clientId: "client-test",
       dateOfBirth: "1990-01-01",
-      assignedStaffId: "test-uid",
+      assignedStaffId: "test-staff-001",
     });
 
     await vi.waitFor(() => {

--- a/frontend/src/components/NewCaseModal.tsx
+++ b/frontend/src/components/NewCaseModal.tsx
@@ -8,7 +8,7 @@ interface Props {
 }
 
 export function NewCaseModal({ onClose, onCreated }: Props) {
-  const { user } = useAuth();
+  const { user, userInfo } = useAuth();
   const [form, setForm] = useState({
     clientName: "",
     clientId: "",
@@ -20,7 +20,7 @@ export function NewCaseModal({ onClose, onCreated }: Props) {
     if (!form.clientName || !form.clientId || !form.dateOfBirth) return;
     setSubmitting(true);
     try {
-      await api.createCase({ ...form, assignedStaffId: user?.uid ?? "" });
+      await api.createCase({ ...form, assignedStaffId: userInfo?.staffId ?? "" });
       onCreated();
     } catch (err) {
       alert(`作成に失敗しました: ${(err as Error).message}`);

--- a/frontend/src/components/NewConsultationModal.test.tsx
+++ b/frontend/src/components/NewConsultationModal.test.tsx
@@ -4,13 +4,6 @@ import userEvent from "@testing-library/user-event";
 import { NewConsultationModal } from "./NewConsultationModal";
 import { TestAuthWrapper } from "../test-utils";
 
-vi.mock("../api", () => ({
-  api: {
-    createConsultation: vi.fn(),
-    createAudioConsultation: vi.fn(),
-  },
-}));
-
 import { api } from "../api";
 
 beforeEach(() => {
@@ -68,7 +61,7 @@ describe("NewConsultationModal", () => {
     vi.mocked(api.createConsultation).mockResolvedValue({
       id: "cons-1",
       caseId: "case-1",
-      staffId: "test-uid",
+      staffId: "test-staff-001",
       content: "テスト内容",
       transcript: "",
       summary: "",
@@ -85,7 +78,7 @@ describe("NewConsultationModal", () => {
     await user.click(screen.getByText("相談を記録"));
 
     expect(api.createConsultation).toHaveBeenCalledWith("case-1", {
-      staffId: "test-uid",
+      staffId: "test-staff-001",
       content: "テスト内容",
       consultationType: "counter",
     });
@@ -99,7 +92,7 @@ describe("NewConsultationModal", () => {
     vi.mocked(api.createAudioConsultation).mockResolvedValue({
       id: "cons-1",
       caseId: "case-1",
-      staffId: "test-uid",
+      staffId: "test-staff-001",
       content: "",
       transcript: "音声のテキスト",
       summary: "AI要約テスト",

--- a/frontend/src/components/NewConsultationModal.tsx
+++ b/frontend/src/components/NewConsultationModal.tsx
@@ -11,7 +11,7 @@ interface Props {
 type Mode = "text" | "audio";
 
 export function NewConsultationModal({ caseId, onClose, onCreated }: Props) {
-  const { user } = useAuth();
+  const { user, userInfo } = useAuth();
   const [mode, setMode] = useState<Mode>("text");
   const [form, setForm] = useState({
     content: "",
@@ -32,7 +32,7 @@ export function NewConsultationModal({ caseId, onClose, onCreated }: Props) {
     try {
       if (mode === "text") {
         await api.createConsultation(caseId, {
-          staffId: user?.uid ?? "",
+          staffId: userInfo?.staffId ?? "",
           content: form.content,
           consultationType: form.consultationType,
         });

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -1,9 +1,11 @@
 import { createContext, useContext, useEffect, useState, type ReactNode } from "react";
 import { onAuthStateChanged, signOut, type User } from "firebase/auth";
 import { auth } from "../firebase";
+import { api, type UserInfo } from "../api";
 
 interface AuthContextType {
   user: User | null;
+  userInfo: UserInfo | null;
   loading: boolean;
   logout: () => Promise<void>;
   getIdToken: () => Promise<string>;
@@ -13,11 +15,22 @@ const AuthContext = createContext<AuthContextType | null>(null);
 
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<User | null>(null);
+  const [userInfo, setUserInfo] = useState<UserInfo | null>(null);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    const unsubscribe = onAuthStateChanged(auth, (u) => {
+    const unsubscribe = onAuthStateChanged(auth, async (u) => {
       setUser(u);
+      if (u) {
+        try {
+          const info = await api.getMe();
+          setUserInfo(info);
+        } catch {
+          setUserInfo(null);
+        }
+      } else {
+        setUserInfo(null);
+      }
       setLoading(false);
     });
     return unsubscribe;
@@ -31,7 +44,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   };
 
   return (
-    <AuthContext.Provider value={{ user, loading, logout, getIdToken }}>
+    <AuthContext.Provider value={{ user, userInfo, loading, logout, getIdToken }}>
       {children}
     </AuthContext.Provider>
   );

--- a/frontend/src/pages/CaseDetail.test.tsx
+++ b/frontend/src/pages/CaseDetail.test.tsx
@@ -5,14 +5,6 @@ import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { CaseDetail } from "./CaseDetail";
 import { TestAuthWrapper } from "../test-utils";
 
-vi.mock("../api", () => ({
-  api: {
-    getCase: vi.fn(),
-    listConsultations: vi.fn(),
-    updateCaseStatus: vi.fn(),
-  },
-}));
-
 import { api } from "../api";
 
 const mockCase = {

--- a/frontend/src/pages/Dashboard.test.tsx
+++ b/frontend/src/pages/Dashboard.test.tsx
@@ -44,12 +44,6 @@ const mockCases = [
   },
 ];
 
-vi.mock("../api", () => ({
-  api: {
-    listCases: vi.fn(),
-  },
-}));
-
 import { api } from "../api";
 
 beforeEach(() => {

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -17,23 +17,23 @@ function formatDate(ts: { _seconds: number }) {
 
 export function Dashboard() {
   const navigate = useNavigate();
-  const { user } = useAuth();
+  const { user, userInfo } = useAuth();
   const [cases, setCases] = useState<Case[]>([]);
   const [loading, setLoading] = useState(true);
   const [showNewCase, setShowNewCase] = useState(false);
 
   const loadCases = useCallback(async () => {
-    if (!user) return;
+    if (!userInfo) return;
     setLoading(true);
     try {
-      const data = await api.listCases(user.uid);
+      const data = await api.listCases(userInfo.staffId);
       setCases(data);
     } catch (err) {
       console.error("Failed to load cases:", err);
     } finally {
       setLoading(false);
     }
-  }, [user]);
+  }, [userInfo]);
 
   useEffect(() => { loadCases(); }, [loadCases]);
 

--- a/frontend/src/test-setup.ts
+++ b/frontend/src/test-setup.ts
@@ -1,6 +1,26 @@
 import "@testing-library/jest-dom/vitest";
 import { vi } from "vitest";
 
+// Mock api module (individual tests can override specific methods)
+vi.mock("./api", () => ({
+  api: {
+    getMe: vi.fn().mockResolvedValue({
+      uid: "test-uid",
+      email: "test@example.com",
+      role: "staff",
+      staffId: "test-staff-001",
+    }),
+    listCases: vi.fn().mockResolvedValue([]),
+    getCase: vi.fn(),
+    createCase: vi.fn(),
+    updateCaseStatus: vi.fn(),
+    listConsultations: vi.fn().mockResolvedValue([]),
+    createConsultation: vi.fn(),
+    createAudioConsultation: vi.fn(),
+    listSupportMenus: vi.fn().mockResolvedValue([]),
+  },
+}));
+
 // Mock Firebase Auth SDK
 vi.mock("./firebase", () => ({
   auth: {

--- a/src/routes/cases.ts
+++ b/src/routes/cases.ts
@@ -9,7 +9,7 @@ import { Timestamp } from "@google-cloud/firestore";
 
 const upload = multer({
   storage: multer.memoryStorage(),
-  limits: { fileSize: 50 * 1024 * 1024 }, // 50MB（約8時間の音声に対応）
+  limits: { fileSize: 25 * 1024 * 1024 }, // 25MB（Cloud Run 32MBリクエスト上限を考慮、ヘッダ・メタデータ分のマージン確保）
   fileFilter: (_req, file, cb) => {
     if (SUPPORTED_AUDIO_MIME_TYPES.includes(file.mimetype as never)) {
       cb(null, true);

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -50,6 +50,7 @@ import * as consultationRepo from "./repositories/consultation-repository.js";
 import * as supportMenuRepo from "./repositories/support-menu-repository.js";
 import { analyzeConsultation, analyzeAudioConsultation } from "./services/ai.js";
 import { Timestamp } from "@google-cloud/firestore";
+import { firebaseAuth, firestore } from "./config.js";
 
 const app = express();
 app.use(express.json());
@@ -59,6 +60,9 @@ app.use("/api/support-menus", supportMenusRouter);
 // App with auth middleware for integration tests
 const authApp = express();
 authApp.use(express.json());
+authApp.get("/api/me", requireAuth, (req, res) => {
+  res.json(req.user);
+});
 authApp.use("/api/cases", requireAuth, casesRouter);
 authApp.use("/api/support-menus", requireAuth, supportMenusRouter);
 
@@ -88,6 +92,41 @@ describe("GET /health", () => {
     const res = await request(healthApp).get("/health");
     expect(res.status).toBe(200);
     expect(res.body.status).toBe("ok");
+  });
+});
+
+describe("GET /api/me", () => {
+  it("returns user info when authenticated", async () => {
+    vi.mocked(firebaseAuth.verifyIdToken).mockResolvedValue({
+      uid: "uid-me",
+      email: "me@example.com",
+    } as never);
+
+    const staffDoc = {
+      id: "staff-me-001",
+      data: () => ({ role: "admin", name: "Me", email: "me@example.com" }),
+    };
+    const mockGet = vi.fn().mockResolvedValue({ empty: false, docs: [staffDoc] });
+    const mockLimit = vi.fn().mockReturnValue({ get: mockGet });
+    const mockWhere = vi.fn().mockReturnValue({ limit: mockLimit });
+    vi.mocked(firestore.collection).mockReturnValue({ where: mockWhere } as never);
+
+    const res = await request(authApp)
+      .get("/api/me")
+      .set("Authorization", "Bearer valid-token");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      uid: "uid-me",
+      email: "me@example.com",
+      role: "admin",
+      staffId: "staff-me-001",
+    });
+  });
+
+  it("returns 401 without auth header", async () => {
+    const res = await request(authApp).get("/api/me");
+    expect(res.status).toBe(401);
   });
 });
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -17,6 +17,11 @@ app.get("/health", (_req, res) => {
   res.json({ status: "ok" });
 });
 
+// Current user info
+app.get("/api/me", requireAuth, (req, res) => {
+  res.json(req.user);
+});
+
 // API routes (protected by Firebase Auth)
 app.use("/api/cases", requireAuth, casesRouter);
 app.use("/api/support-menus", requireAuth, supportMenusRouter);


### PR DESCRIPTION
## Summary
- FEがFirebase UIDではなくFirestore staffドキュメントIDを使うよう修正（staffIdバグ）
- `/api/me` エンドポイント追加（認証後のstaffId/role取得用）
- multerファイルサイズ上限を25MBに変更（Cloud Run 32MB制限考慮）

## 変更内容
### バグ修正: staffId不整合
- `AuthContext`にuserInfo(staffId, role)を追加、ログイン後に`/api/me`で取得
- `NewCaseModal`, `NewConsultationModal`, `Dashboard`でFirestore staffIdを使用
- テストのstaffId期待値を修正

### ファイルサイズ制限
- multer上限: 50MB → 25MB（Cloud Run 32MBリクエスト上限のマージン確保）

## Test plan
- [x] BE: 52テスト全パス（/api/meテスト2件追加）
- [x] FE: 56テスト全パス（staffId期待値修正済み）
- [x] TypeScript型チェック通過
- [x] ESLint通過
- [ ] CI通過確認
- [ ] Cloud Runデプロイ後にE2E確認（ログイン→ケース作成→音声→一覧反映）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced authentication system to fetch and expose staff information as part of user profiles

* **Improvements**
  * Updated user data handling in case and consultation creation workflows

* **Changes**
  * Reduced maximum file upload limit from 50MB to 25MB

* **Tests**
  * Updated test setup and mocks to reflect changes in authentication structure and user data handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->