### PR TITLE
fix: 音声モードstaffId修正漏れ + authError表示 + テスト追加

### DIFF
--- a/frontend/src/components/NewConsultationModal.test.tsx
+++ b/frontend/src/components/NewConsultationModal.test.tsx
@@ -88,6 +88,37 @@ describe("NewConsultationModal", () => {
     });
   });
 
+  it("sends staffId from userInfo (not uid) in audio mode", async () => {
+    vi.mocked(api.createAudioConsultation).mockResolvedValue({
+      id: "cons-1",
+      caseId: "case-1",
+      staffId: "test-staff-001",
+      content: "",
+      transcript: "text",
+      summary: "summary",
+      suggestedSupports: [],
+      consultationType: "counter",
+      createdAt: { _seconds: 1700000000 },
+      updatedAt: { _seconds: 1700000000 },
+    });
+
+    renderModal();
+    const user = userEvent.setup();
+
+    await user.click(screen.getByText(/音声ファイル/));
+    const file = new File(["audio-data"], "test.wav", { type: "audio/wav" });
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+    await user.upload(fileInput, file);
+    await user.click(screen.getByText("音声を分析・記録"));
+
+    await vi.waitFor(() => {
+      expect(api.createAudioConsultation).toHaveBeenCalled();
+    });
+
+    const formData = vi.mocked(api.createAudioConsultation).mock.calls[0][1] as FormData;
+    expect(formData.get("staffId")).toBe("test-staff-001");
+  });
+
   it("shows AI result after audio submission", async () => {
     vi.mocked(api.createAudioConsultation).mockResolvedValue({
       id: "cons-1",

--- a/frontend/src/components/NewConsultationModal.tsx
+++ b/frontend/src/components/NewConsultationModal.tsx
@@ -40,7 +40,7 @@ export function NewConsultationModal({ caseId, onClose, onCreated }: Props) {
       } else if (audioFile) {
         const formData = new FormData();
         formData.append("audio", audioFile);
-        formData.append("staffId", user?.uid ?? "");
+        formData.append("staffId", userInfo?.staffId ?? "");
         formData.append("consultationType", form.consultationType);
         formData.append("context", form.context);
 

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -7,6 +7,7 @@ interface AuthContextType {
   user: User | null;
   userInfo: UserInfo | null;
   loading: boolean;
+  authError: string | null;
   logout: () => Promise<void>;
   getIdToken: () => Promise<string>;
 }
@@ -17,16 +18,19 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<User | null>(null);
   const [userInfo, setUserInfo] = useState<UserInfo | null>(null);
   const [loading, setLoading] = useState(true);
+  const [authError, setAuthError] = useState<string | null>(null);
 
   useEffect(() => {
     const unsubscribe = onAuthStateChanged(auth, async (u) => {
       setUser(u);
+      setAuthError(null);
       if (u) {
         try {
           const info = await api.getMe();
           setUserInfo(info);
-        } catch {
+        } catch (err) {
           setUserInfo(null);
+          setAuthError(`職員情報の取得に失敗しました: ${(err as Error).message}`);
         }
       } else {
         setUserInfo(null);
@@ -44,7 +48,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   };
 
   return (
-    <AuthContext.Provider value={{ user, userInfo, loading, logout, getIdToken }}>
+    <AuthContext.Provider value={{ user, userInfo, loading, authError, logout, getIdToken }}>
       {children}
     </AuthContext.Provider>
   );

--- a/frontend/src/pages/Dashboard.test.tsx
+++ b/frontend/src/pages/Dashboard.test.tsx
@@ -48,6 +48,12 @@ import { api } from "../api";
 
 beforeEach(() => {
   vi.mocked(api.listCases).mockReset();
+  vi.mocked(api.getMe).mockReset().mockResolvedValue({
+    uid: "test-uid",
+    email: "test@example.com",
+    role: "staff",
+    staffId: "test-staff-001",
+  });
 });
 
 function renderDashboard() {
@@ -113,6 +119,16 @@ describe("Dashboard", () => {
     await user.click(screen.getByText("最初のケースを作成"));
 
     expect(screen.getByText("新規ケース作成")).toBeInTheDocument();
+  });
+
+  it("shows auth error when getMe fails", async () => {
+    vi.mocked(api.getMe).mockRejectedValue(new Error("Network error"));
+    vi.mocked(api.listCases).mockResolvedValue([]);
+    renderDashboard();
+
+    await waitFor(() => {
+      expect(screen.getByText(/職員情報の取得に失敗しました/)).toBeInTheDocument();
+    });
   });
 
   it("displays status labels in Japanese", async () => {

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -17,7 +17,7 @@ function formatDate(ts: { _seconds: number }) {
 
 export function Dashboard() {
   const navigate = useNavigate();
-  const { user, userInfo } = useAuth();
+  const { user, userInfo, authError } = useAuth();
   const [cases, setCases] = useState<Case[]>([]);
   const [loading, setLoading] = useState(true);
   const [showNewCase, setShowNewCase] = useState(false);
@@ -48,9 +48,14 @@ export function Dashboard() {
     <>
       <div className="page-header">
         <h1>ケース一覧</h1>
-        <p className="page-header-subtitle">担当: {user?.email}</p>
+        <p className="page-header-subtitle">担当: {userInfo?.staffId ?? user?.email}</p>
       </div>
       <div className="page-body">
+        {authError && (
+          <div className="alert alert-error" style={{ marginBottom: "var(--space-5)", padding: "var(--space-4)", background: "var(--kuri-50)", border: "1px solid var(--kuri-200)", borderRadius: "var(--radius-md)", color: "var(--kuri-700)" }}>
+            {authError}
+          </div>
+        )}
         <div className="stats-bar">
           <div className="stat-card">
             <div className="stat-value">{stats.total}</div>

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -128,6 +128,57 @@ describe("GET /api/me", () => {
     const res = await request(authApp).get("/api/me");
     expect(res.status).toBe(401);
   });
+
+  it("auto-provisions staff doc when not found in Firestore", async () => {
+    vi.mocked(firebaseAuth.verifyIdToken).mockResolvedValue({
+      uid: "uid-new",
+      email: "new@example.com",
+      name: "New User",
+    } as never);
+
+    const mockSet = vi.fn().mockResolvedValue(undefined);
+    const mockDoc = vi.fn().mockReturnValue({ id: "auto-staff-001", set: mockSet });
+    const mockGet = vi.fn().mockResolvedValue({ empty: true, docs: [] });
+    const mockLimit = vi.fn().mockReturnValue({ get: mockGet });
+    const mockWhere = vi.fn().mockReturnValue({ limit: mockLimit });
+    vi.mocked(firestore.collection).mockReturnValue({ where: mockWhere, doc: mockDoc } as never);
+
+    const res = await request(authApp)
+      .get("/api/me")
+      .set("Authorization", "Bearer valid-token");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      uid: "uid-new",
+      email: "new@example.com",
+      role: "staff",
+      staffId: "auto-staff-001",
+    });
+    expect(mockSet).toHaveBeenCalledWith(expect.objectContaining({
+      firebaseUid: "uid-new",
+      email: "new@example.com",
+      role: "staff",
+    }));
+  });
+
+  it("returns 401 when Firestore query fails", async () => {
+    vi.mocked(firebaseAuth.verifyIdToken).mockResolvedValue({
+      uid: "uid-err",
+      email: "err@example.com",
+    } as never);
+
+    const mockGet = vi.fn().mockRejectedValue(new Error("Firestore unavailable"));
+    const mockLimit = vi.fn().mockReturnValue({ get: mockGet });
+    const mockWhere = vi.fn().mockReturnValue({ limit: mockLimit });
+    vi.mocked(firestore.collection).mockReturnValue({ where: mockWhere } as never);
+
+    const res = await request(authApp)
+      .get("/api/me")
+      .set("Authorization", "Bearer valid-token");
+
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe("Authentication failed");
+  });
 });
 
 describe("POST /api/cases", () => {


### PR DESCRIPTION
## Summary
- 音声モードFormDataの`staffId`が`user.uid`のまま（PR#10の修正漏れ）→ `userInfo.staffId`に修正
- AuthContextに`authError`状態を追加し、`/api/me`失敗時にDashboardにエラーバナー表示
- Dashboard担当者表示を`user.email`→`userInfo.staffId`に改善
- BEテスト2件追加: staff auto-provision + Firestore障害時401
- FEテスト2件追加: 音声モードstaffId検証 + authError表示

Closes #10 のフォローアップ

## Test plan
- [x] BE: 54テスト全パス（+2件）
- [x] FE: 58テスト全パス（+2件）
- [x] TypeScript型チェック通過
- [x] ESLint通過
- [ ] CI通過確認
- [ ] Cloud Runデプロイ後にE2E確認（音声モードstaffId + authError非表示）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the staff identifier used when creating audio consultations.

* **New Features**
  * Authentication errors are now displayed in the dashboard.
  * Dashboard shows additional staff information when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->