### PR TITLE
fix: staff自動プロビジョニングの競合対策

### DIFF
--- a/src/middleware/auth.test.ts
+++ b/src/middleware/auth.test.ts
@@ -77,15 +77,15 @@ describe("requireAuth middleware", () => {
     expect(next).not.toHaveBeenCalled();
   });
 
-  it("auto-provisions staff document on first login", async () => {
+  it("auto-provisions staff document on first login (idempotent create)", async () => {
     vi.mocked(firebaseAuth.verifyIdToken).mockResolvedValue({
       uid: "new-uid",
       email: "new@example.com",
       name: "New User",
     } as never);
 
-    const mockSet = vi.fn().mockResolvedValue(undefined);
-    const mockDoc = vi.fn().mockReturnValue({ id: "auto-staff-001", set: mockSet });
+    const mockCreate = vi.fn().mockResolvedValue(undefined);
+    const mockDoc = vi.fn().mockReturnValue({ id: "new-uid", create: mockCreate });
     const mockGet = vi.fn().mockResolvedValue({ empty: true, docs: [] });
     const mockLimit = vi.fn().mockReturnValue({ get: mockGet });
     const mockWhere = vi.fn().mockReturnValue({ limit: mockLimit });
@@ -99,7 +99,8 @@ describe("requireAuth middleware", () => {
     await requireAuth(req, res, next);
 
     expect(next).toHaveBeenCalled();
-    expect(mockSet).toHaveBeenCalledWith(expect.objectContaining({
+    expect(mockDoc).toHaveBeenCalledWith("new-uid");
+    expect(mockCreate).toHaveBeenCalledWith(expect.objectContaining({
       firebaseUid: "new-uid",
       email: "new@example.com",
       role: "staff",
@@ -108,7 +109,43 @@ describe("requireAuth middleware", () => {
       uid: "new-uid",
       email: "new@example.com",
       role: "staff",
-      staffId: "auto-staff-001",
+      staffId: "new-uid",
+    });
+  });
+
+  it("handles concurrent auto-provision (ALREADY_EXISTS)", async () => {
+    vi.mocked(firebaseAuth.verifyIdToken).mockResolvedValue({
+      uid: "race-uid",
+      email: "race@example.com",
+    } as never);
+
+    const alreadyExistsErr = new Error("Document already exists") as Error & { code: number };
+    alreadyExistsErr.code = 6; // gRPC ALREADY_EXISTS
+    const mockCreate = vi.fn().mockRejectedValue(alreadyExistsErr);
+    const mockDocGet = vi.fn().mockResolvedValue({
+      id: "race-uid",
+      data: () => ({ role: "staff", email: "race@example.com", name: "" }),
+    });
+    const mockDoc = vi.fn().mockReturnValue({ id: "race-uid", create: mockCreate, get: mockDocGet });
+    const mockQueryGet = vi.fn().mockResolvedValue({ empty: true, docs: [] });
+    const mockLimit = vi.fn().mockReturnValue({ get: mockQueryGet });
+    const mockWhere = vi.fn().mockReturnValue({ limit: mockLimit });
+    vi.mocked(firestore.collection).mockReturnValue({
+      where: mockWhere,
+      doc: mockDoc,
+    } as never);
+
+    const { req, res, next } = mockReqResNext("Bearer race-token");
+
+    await requireAuth(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(mockDocGet).toHaveBeenCalled();
+    expect(req.user).toEqual({
+      uid: "race-uid",
+      email: "race@example.com",
+      role: "staff",
+      staffId: "race-uid",
     });
   });
 

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -24,16 +24,30 @@ export async function requireAuth(req: Request, res: Response, next: NextFunctio
 
     if (staffQuery.empty) {
       // Auto-provision: 初回ログイン時にstaffドキュメントを自動作成
-      const newStaffRef = firestore.collection("staff").doc();
-      await newStaffRef.set({
-        firebaseUid: decoded.uid,
-        email: decoded.email ?? "",
-        name: decoded.name ?? "",
-        role: "staff",
-        createdAt: new Date(),
-      });
-      staffId = newStaffRef.id;
-      role = "staff";
+      // firebaseUidをドキュメントIDに使い、create()で冪等に作成（競合対策）
+      const newStaffRef = firestore.collection("staff").doc(decoded.uid);
+      try {
+        await newStaffRef.create({
+          firebaseUid: decoded.uid,
+          email: decoded.email ?? "",
+          name: decoded.name ?? "",
+          role: "staff",
+          createdAt: new Date(),
+        });
+        staffId = newStaffRef.id;
+        role = "staff";
+      } catch (provisionErr: unknown) {
+        const code = (provisionErr as { code?: number }).code;
+        if (code === 6) {
+          // ALREADY_EXISTS: 同時リクエストが先に作成済み
+          const existingDoc = await newStaffRef.get();
+          const existingData = existingDoc.data()!;
+          staffId = existingDoc.id;
+          role = (existingData.role as "admin" | "staff") ?? "staff";
+        } else {
+          throw provisionErr;
+        }
+      }
     } else {
       const staffDoc = staffQuery.docs[0];
       const staffData = staffDoc.data();

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -153,8 +153,8 @@ describe("GET /api/me", () => {
       name: "New User",
     } as never);
 
-    const mockSet = vi.fn().mockResolvedValue(undefined);
-    const mockDoc = vi.fn().mockReturnValue({ id: "auto-staff-001", set: mockSet });
+    const mockCreate = vi.fn().mockResolvedValue(undefined);
+    const mockDoc = vi.fn().mockReturnValue({ id: "uid-new", create: mockCreate });
     const mockGet = vi.fn().mockResolvedValue({ empty: true, docs: [] });
     const mockLimit = vi.fn().mockReturnValue({ get: mockGet });
     const mockWhere = vi.fn().mockReturnValue({ limit: mockLimit });
@@ -169,9 +169,9 @@ describe("GET /api/me", () => {
       uid: "uid-new",
       email: "new@example.com",
       role: "staff",
-      staffId: "auto-staff-001",
+      staffId: "uid-new",
     });
-    expect(mockSet).toHaveBeenCalledWith(expect.objectContaining({
+    expect(mockCreate).toHaveBeenCalledWith(expect.objectContaining({
       firebaseUid: "uid-new",
       email: "new@example.com",
       role: "staff",


### PR DESCRIPTION
## Summary
- 同一ユーザーの初回ログイン時、同時リクエストでstaffドキュメントが重複作成される問題を修正
- `doc()` → `doc(decoded.uid)` でfirebaseUidをドキュメントIDに使用（冪等）
- `set()` → `create()` でALREADY_EXISTS (gRPC code 6) をキャッチし既存ドキュメントを読み取り

## Test plan
- [x] BE: 64テスト全パス（競合テスト1件追加）
- [x] FE: 57テスト全パス（変更なし）
- [x] TypeScript型チェック通過
- [ ] CI通過確認

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)