### PR TITLE
fix: staff auto-provision 異常系ハードニング

### DIFF
--- a/src/middleware/auth.test.ts
+++ b/src/middleware/auth.test.ts
@@ -149,6 +149,64 @@ describe("requireAuth middleware", () => {
     });
   });
 
+  it("returns 401 when create() fails with non-ALREADY_EXISTS error", async () => {
+    vi.mocked(firebaseAuth.verifyIdToken).mockResolvedValue({
+      uid: "err-uid",
+      email: "err@example.com",
+    } as never);
+
+    const firestoreErr = new Error("Permission denied") as Error & { code: number };
+    firestoreErr.code = 7; // gRPC PERMISSION_DENIED
+    const mockCreate = vi.fn().mockRejectedValue(firestoreErr);
+    const mockDoc = vi.fn().mockReturnValue({ id: "err-uid", create: mockCreate });
+    const mockGet = vi.fn().mockResolvedValue({ empty: true, docs: [] });
+    const mockLimit = vi.fn().mockReturnValue({ get: mockGet });
+    const mockWhere = vi.fn().mockReturnValue({ limit: mockLimit });
+    vi.mocked(firestore.collection).mockReturnValue({
+      where: mockWhere,
+      doc: mockDoc,
+    } as never);
+
+    const { req, res, next } = mockReqResNext("Bearer err-token");
+
+    await requireAuth(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ error: "Authentication failed" });
+  });
+
+  it("returns 401 when ALREADY_EXISTS doc has no data", async () => {
+    vi.mocked(firebaseAuth.verifyIdToken).mockResolvedValue({
+      uid: "nodata-uid",
+      email: "nodata@example.com",
+    } as never);
+
+    const alreadyExistsErr = new Error("Document already exists") as Error & { code: number };
+    alreadyExistsErr.code = 6;
+    const mockCreate = vi.fn().mockRejectedValue(alreadyExistsErr);
+    const mockDocGet = vi.fn().mockResolvedValue({
+      id: "nodata-uid",
+      data: () => undefined,
+    });
+    const mockDoc = vi.fn().mockReturnValue({ id: "nodata-uid", create: mockCreate, get: mockDocGet });
+    const mockQueryGet = vi.fn().mockResolvedValue({ empty: true, docs: [] });
+    const mockLimit = vi.fn().mockReturnValue({ get: mockQueryGet });
+    const mockWhere = vi.fn().mockReturnValue({ limit: mockLimit });
+    vi.mocked(firestore.collection).mockReturnValue({
+      where: mockWhere,
+      doc: mockDoc,
+    } as never);
+
+    const { req, res, next } = mockReqResNext("Bearer nodata-token");
+
+    await requireAuth(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ error: "Authentication failed" });
+  });
+
   it("calls next() and sets req.user when authentication succeeds", async () => {
     vi.mocked(firebaseAuth.verifyIdToken).mockResolvedValue({
       uid: "firebase-uid-1",

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -41,7 +41,10 @@ export async function requireAuth(req: Request, res: Response, next: NextFunctio
         if (code === 6) {
           // ALREADY_EXISTS: 同時リクエストが先に作成済み
           const existingDoc = await newStaffRef.get();
-          const existingData = existingDoc.data()!;
+          const existingData = existingDoc.data();
+          if (!existingData) {
+            throw new Error("Staff document exists but has no data");
+          }
           staffId = existingDoc.id;
           role = (existingData.role as "admin" | "staff") ?? "staff";
         } else {


### PR DESCRIPTION
## Summary
PR #25 で対応した staff 競合対策のレビュー不足を補完:
- `data()!` の non-null assertion を除去し、undefined 時にエラーを throw
- `create()` が ALREADY_EXISTS 以外で失敗するパスのテスト追加
- ALREADY_EXISTS 後に `data()` が undefined を返すエッジケースのテスト追加
- staffドキュメント削除時の不整合リスクを Issue #26 として記録

## Test plan
- [x] BE: 66テスト全パス（異常系テスト2件追加）
- [x] FE: 57テスト全パス（変更なし）
- [x] TypeScript型チェック通過
- [ ] CI通過確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)