### PR TITLE
fix: Firestoreエラー時のHTTPステータスを401→500に修正

### DIFF
--- a/src/middleware/auth.test.ts
+++ b/src/middleware/auth.test.ts
@@ -149,7 +149,7 @@ describe("requireAuth middleware", () => {
     });
   });
 
-  it("returns 401 when create() fails with non-ALREADY_EXISTS error", async () => {
+  it("returns 500 when create() fails with non-ALREADY_EXISTS error", async () => {
     vi.mocked(firebaseAuth.verifyIdToken).mockResolvedValue({
       uid: "err-uid",
       email: "err@example.com",
@@ -172,11 +172,11 @@ describe("requireAuth middleware", () => {
     await requireAuth(req, res, next);
 
     expect(next).not.toHaveBeenCalled();
-    expect(res.status).toHaveBeenCalledWith(401);
-    expect(res.json).toHaveBeenCalledWith({ error: "Authentication failed" });
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({ error: "Internal server error" });
   });
 
-  it("returns 401 when ALREADY_EXISTS doc has no data", async () => {
+  it("returns 500 when ALREADY_EXISTS doc has no data", async () => {
     vi.mocked(firebaseAuth.verifyIdToken).mockResolvedValue({
       uid: "nodata-uid",
       email: "nodata@example.com",
@@ -203,8 +203,8 @@ describe("requireAuth middleware", () => {
     await requireAuth(req, res, next);
 
     expect(next).not.toHaveBeenCalled();
-    expect(res.status).toHaveBeenCalledWith(401);
-    expect(res.json).toHaveBeenCalledWith({ error: "Authentication failed" });
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({ error: "Internal server error" });
   });
 
   it("calls next() and sets req.user when authentication succeeds", async () => {

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -9,10 +9,23 @@ export async function requireAuth(req: Request, res: Response, next: NextFunctio
   }
 
   const idToken = authHeader.slice(7);
-  try {
-    const decoded = await firebaseAuth.verifyIdToken(idToken);
 
-    // Firestoreのstaffコレクションからユーザー情報を取得
+  // Step 1: Firebase IDトークン検証（失敗 → 401）
+  let decoded;
+  try {
+    decoded = await firebaseAuth.verifyIdToken(idToken);
+  } catch (err) {
+    const message = (err as Error).message;
+    if (message.includes("expired") || message.includes("Decoding Firebase ID token failed")) {
+      res.status(401).json({ error: "Invalid or expired token" });
+    } else {
+      res.status(401).json({ error: "Authentication failed" });
+    }
+    return;
+  }
+
+  // Step 2: Firestoreからスタッフ情報取得/作成（失敗 → 500）
+  try {
     const staffQuery = await firestore
       .collection("staff")
       .where("firebaseUid", "==", decoded.uid)
@@ -67,11 +80,11 @@ export async function requireAuth(req: Request, res: Response, next: NextFunctio
 
     next();
   } catch (err) {
-    const message = (err as Error).message;
-    if (message.includes("expired") || message.includes("Decoding Firebase ID token failed")) {
-      res.status(401).json({ error: "Invalid or expired token" });
-    } else {
-      res.status(401).json({ error: "Authentication failed" });
-    }
+    console.error("Staff lookup/provision failed", {
+      uid: decoded.uid,
+      error: (err as Error).message,
+      code: (err as { code?: number }).code,
+    });
+    res.status(500).json({ error: "Internal server error" });
   }
 }

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -178,7 +178,7 @@ describe("GET /api/me", () => {
     }));
   });
 
-  it("returns 401 when Firestore query fails", async () => {
+  it("returns 500 when Firestore query fails", async () => {
     vi.mocked(firebaseAuth.verifyIdToken).mockResolvedValue({
       uid: "uid-err",
       email: "err@example.com",
@@ -193,8 +193,8 @@ describe("GET /api/me", () => {
       .get("/api/me")
       .set("Authorization", "Bearer valid-token");
 
-    expect(res.status).toBe(401);
-    expect(res.body.error).toBe("Authentication failed");
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe("Internal server error");
   });
 });
 


### PR DESCRIPTION
## Summary
- `requireAuth` の外側 catch が token 検証エラーと Firestore エラーを区別せず全て 401 を返していたバグを修正
- `verifyIdToken` の catch（→ 401）と Firestore 操作の catch（→ 500）を分離
- テスト期待値を `401` → `500` に更新（auth.test.ts, server.test.ts）

## Test plan
- [x] BE: 66テスト全パス
- [x] TypeScript型チェック通過
- [x] ESLint通過
- [ ] CI通過確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Authenticated users are now automatically provisioned in the system upon first login.

* **Bug Fixes**
  * Improved authentication error handling with more appropriate HTTP status codes and error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->