### PR TITLE
security: 未許可ユーザーのstaff自動登録を制限

### DIFF
--- a/src/middleware/auth.test.ts
+++ b/src/middleware/auth.test.ts
@@ -77,10 +77,68 @@ describe("requireAuth middleware", () => {
     expect(next).not.toHaveBeenCalled();
   });
 
+  it("returns 403 when email is not verified (new user)", async () => {
+    vi.mocked(firebaseAuth.verifyIdToken).mockResolvedValue({
+      uid: "unverified-uid",
+      email: "unverified@example.com",
+      email_verified: false,
+    } as never);
+
+    const mockGet = vi.fn().mockResolvedValue({ empty: true, docs: [] });
+    const mockLimit = vi.fn().mockReturnValue({ get: mockGet });
+    const mockWhere = vi.fn().mockReturnValue({ limit: mockLimit });
+    vi.mocked(firestore.collection).mockReturnValue({ where: mockWhere } as never);
+
+    const { req, res, next } = mockReqResNext("Bearer unverified-token");
+
+    await requireAuth(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({ error: "Email not verified" });
+  });
+
+  it("returns 403 when email domain is not allowed (new user)", async () => {
+    // Set allowed domains for this test
+    const originalEnv = process.env.ALLOWED_EMAIL_DOMAINS;
+    process.env.ALLOWED_EMAIL_DOMAINS = "allowed.gov.jp";
+
+    // Re-import to pick up env change
+    vi.resetModules();
+    vi.mock("../config.js", () => ({
+      firebaseAuth: { verifyIdToken: vi.fn() },
+      firestore: { collection: vi.fn() },
+    }));
+    const { requireAuth: freshRequireAuth } = await import("./auth.js");
+    const { firebaseAuth: freshFirebaseAuth, firestore: freshFirestore } = await import("../config.js");
+
+    vi.mocked(freshFirebaseAuth.verifyIdToken).mockResolvedValue({
+      uid: "blocked-uid",
+      email: "blocked@notallowed.com",
+      email_verified: true,
+    } as never);
+
+    const mockGet = vi.fn().mockResolvedValue({ empty: true, docs: [] });
+    const mockLimit = vi.fn().mockReturnValue({ get: mockGet });
+    const mockWhere = vi.fn().mockReturnValue({ limit: mockLimit });
+    vi.mocked(freshFirestore.collection).mockReturnValue({ where: mockWhere } as never);
+
+    const { req, res, next } = mockReqResNext("Bearer blocked-token");
+
+    await freshRequireAuth(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({ error: "Access denied: email domain not allowed" });
+
+    process.env.ALLOWED_EMAIL_DOMAINS = originalEnv;
+  });
+
   it("auto-provisions staff document on first login (idempotent create)", async () => {
     vi.mocked(firebaseAuth.verifyIdToken).mockResolvedValue({
       uid: "new-uid",
       email: "new@example.com",
+      email_verified: true,
       name: "New User",
     } as never);
 
@@ -117,6 +175,7 @@ describe("requireAuth middleware", () => {
     vi.mocked(firebaseAuth.verifyIdToken).mockResolvedValue({
       uid: "race-uid",
       email: "race@example.com",
+      email_verified: true,
     } as never);
 
     const alreadyExistsErr = new Error("Document already exists") as Error & { code: number };
@@ -153,6 +212,7 @@ describe("requireAuth middleware", () => {
     vi.mocked(firebaseAuth.verifyIdToken).mockResolvedValue({
       uid: "err-uid",
       email: "err@example.com",
+      email_verified: true,
     } as never);
 
     const firestoreErr = new Error("Permission denied") as Error & { code: number };
@@ -180,6 +240,7 @@ describe("requireAuth middleware", () => {
     vi.mocked(firebaseAuth.verifyIdToken).mockResolvedValue({
       uid: "nodata-uid",
       email: "nodata@example.com",
+      email_verified: true,
     } as never);
 
     const alreadyExistsErr = new Error("Document already exists") as Error & { code: number };

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -1,6 +1,21 @@
 import { Request, Response, NextFunction } from "express";
 import { firebaseAuth } from "../config.js";
 import { firestore } from "../config.js";
+
+const allowedDomains = process.env.ALLOWED_EMAIL_DOMAINS
+  ? process.env.ALLOWED_EMAIL_DOMAINS.split(",").map((d) => d.trim().toLowerCase())
+  : null;
+
+if (!allowedDomains) {
+  console.warn("WARNING: ALLOWED_EMAIL_DOMAINS is not set. Any authenticated user can auto-provision as staff.");
+}
+
+function isEmailAllowed(email: string): boolean {
+  if (!allowedDomains) return true;
+  const domain = email.split("@")[1]?.toLowerCase();
+  return !!domain && allowedDomains.includes(domain);
+}
+
 export async function requireAuth(req: Request, res: Response, next: NextFunction): Promise<void> {
   const authHeader = req.headers.authorization;
   if (!authHeader?.startsWith("Bearer ")) {
@@ -36,6 +51,16 @@ export async function requireAuth(req: Request, res: Response, next: NextFunctio
     let role: "admin" | "staff";
 
     if (staffQuery.empty) {
+      // 未登録ユーザーのアクセス制御
+      if (!decoded.email_verified) {
+        res.status(403).json({ error: "Email not verified" });
+        return;
+      }
+      if (!isEmailAllowed(decoded.email ?? "")) {
+        res.status(403).json({ error: "Access denied: email domain not allowed" });
+        return;
+      }
+
       // Auto-provision: 初回ログイン時にstaffドキュメントを自動作成
       // firebaseUidをドキュメントIDに使い、create()で冪等に作成（競合対策）
       const newStaffRef = firestore.collection("staff").doc(decoded.uid);

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -150,6 +150,7 @@ describe("GET /api/me", () => {
     vi.mocked(firebaseAuth.verifyIdToken).mockResolvedValue({
       uid: "uid-new",
       email: "new@example.com",
+      email_verified: true,
       name: "New User",
     } as never);
 


### PR DESCRIPTION
## Summary
- `ALLOWED_EMAIL_DOMAINS`環境変数によるメールドメイン制限を追加
- `email_verified`未確認ユーザーの自動登録を403で拒否
- 許可外ドメインのユーザーの自動登録を403で拒否
- 環境変数未設定時は全ドメイン許可（警告ログ出力）

## Test plan
- [x] BE: 68テスト全パス（email未検証→403、ドメイン拒否→403のテスト2件追加）
- [x] ESLint通過
- [ ] CI通過確認

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)