### PR TITLE
fix: ドメイン制限エッジケース修正 + テストハードニング

### DIFF
--- a/src/middleware/auth.test.ts
+++ b/src/middleware/auth.test.ts
@@ -98,6 +98,99 @@ describe("requireAuth middleware", () => {
     expect(res.json).toHaveBeenCalledWith({ error: "Email not verified" });
   });
 
+  it("returns 403 when email_verified is undefined (new user)", async () => {
+    vi.mocked(firebaseAuth.verifyIdToken).mockResolvedValue({
+      uid: "no-verified-field-uid",
+      email: "nofield@example.com",
+      // email_verified intentionally omitted (undefined)
+    } as never);
+
+    const mockGet = vi.fn().mockResolvedValue({ empty: true, docs: [] });
+    const mockLimit = vi.fn().mockReturnValue({ get: mockGet });
+    const mockWhere = vi.fn().mockReturnValue({ limit: mockLimit });
+    vi.mocked(firestore.collection).mockReturnValue({ where: mockWhere } as never);
+
+    const { req, res, next } = mockReqResNext("Bearer no-verified-token");
+
+    await requireAuth(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({ error: "Email not verified" });
+  });
+
+  it("returns 403 when email is undefined (new user)", async () => {
+    vi.mocked(firebaseAuth.verifyIdToken).mockResolvedValue({
+      uid: "no-email-uid",
+      email_verified: true,
+      // email intentionally omitted
+    } as never);
+
+    const mockGet = vi.fn().mockResolvedValue({ empty: true, docs: [] });
+    const mockLimit = vi.fn().mockReturnValue({ get: mockGet });
+    const mockWhere = vi.fn().mockReturnValue({ limit: mockLimit });
+    vi.mocked(firestore.collection).mockReturnValue({ where: mockWhere } as never);
+
+    const { req, res, next } = mockReqResNext("Bearer no-email-token");
+
+    await requireAuth(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({ error: "Email is required for auto-provisioning" });
+  });
+
+  it("treats empty ALLOWED_EMAIL_DOMAINS as unset (fail-open)", async () => {
+    const originalEnv = process.env.ALLOWED_EMAIL_DOMAINS;
+    process.env.ALLOWED_EMAIL_DOMAINS = "   ,  ,";
+
+    vi.resetModules();
+    vi.mock("../config.js", () => ({
+      firebaseAuth: { verifyIdToken: vi.fn() },
+      firestore: { collection: vi.fn() },
+    }));
+    const { requireAuth: freshRequireAuth } = await import("./auth.js");
+    const { firebaseAuth: freshFirebaseAuth, firestore: freshFirestore } = await import("../config.js");
+
+    vi.mocked(freshFirebaseAuth.verifyIdToken).mockResolvedValue({
+      uid: "empty-env-uid",
+      email: "user@anydomain.com",
+      email_verified: true,
+    } as never);
+
+    const mockCreate = vi.fn().mockResolvedValue(undefined);
+    const mockDoc = vi.fn().mockReturnValue({ id: "empty-env-uid", create: mockCreate });
+    const mockGet = vi.fn().mockResolvedValue({ empty: true, docs: [] });
+    const mockLimit = vi.fn().mockReturnValue({ get: mockGet });
+    const mockWhere = vi.fn().mockReturnValue({ limit: mockLimit });
+    vi.mocked(freshFirestore.collection).mockReturnValue({
+      where: mockWhere,
+      doc: mockDoc,
+    } as never);
+
+    const { req, res, next } = mockReqResNext("Bearer empty-env-token");
+
+    await freshRequireAuth(req, res, next);
+
+    // fail-open: 空のドメインリストは未設定扱い → auto-provision成功
+    expect(next).toHaveBeenCalled();
+    expect(mockCreate).toHaveBeenCalled();
+
+    process.env.ALLOWED_EMAIL_DOMAINS = originalEnv;
+  });
+
+  it("returns 401 when Bearer token is empty string", async () => {
+    vi.mocked(firebaseAuth.verifyIdToken).mockRejectedValue(
+      new Error("Decoding Firebase ID token failed"),
+    );
+    const { req, res, next } = mockReqResNext("Bearer ");
+
+    await requireAuth(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+
   it("returns 403 when email domain is not allowed (new user)", async () => {
     // Set allowed domains for this test
     const originalEnv = process.env.ALLOWED_EMAIL_DOMAINS;
@@ -132,6 +225,79 @@ describe("requireAuth middleware", () => {
     expect(res.json).toHaveBeenCalledWith({ error: "Access denied: email domain not allowed" });
 
     process.env.ALLOWED_EMAIL_DOMAINS = originalEnv;
+  });
+
+  it("auto-provisions when email domain matches ALLOWED_EMAIL_DOMAINS", async () => {
+    const originalEnv = process.env.ALLOWED_EMAIL_DOMAINS;
+    process.env.ALLOWED_EMAIL_DOMAINS = "allowed.gov.jp,another.org";
+
+    vi.resetModules();
+    vi.mock("../config.js", () => ({
+      firebaseAuth: { verifyIdToken: vi.fn() },
+      firestore: { collection: vi.fn() },
+    }));
+    const { requireAuth: freshRequireAuth } = await import("./auth.js");
+    const { firebaseAuth: freshFirebaseAuth, firestore: freshFirestore } = await import("../config.js");
+
+    vi.mocked(freshFirebaseAuth.verifyIdToken).mockResolvedValue({
+      uid: "allowed-uid",
+      email: "user@allowed.gov.jp",
+      email_verified: true,
+    } as never);
+
+    const mockCreate = vi.fn().mockResolvedValue(undefined);
+    const mockDoc = vi.fn().mockReturnValue({ id: "allowed-uid", create: mockCreate });
+    const mockGet = vi.fn().mockResolvedValue({ empty: true, docs: [] });
+    const mockLimit = vi.fn().mockReturnValue({ get: mockGet });
+    const mockWhere = vi.fn().mockReturnValue({ limit: mockLimit });
+    vi.mocked(freshFirestore.collection).mockReturnValue({
+      where: mockWhere,
+      doc: mockDoc,
+    } as never);
+
+    const { req, res, next } = mockReqResNext("Bearer allowed-token");
+
+    await freshRequireAuth(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(mockCreate).toHaveBeenCalled();
+    expect(req.user).toEqual({
+      uid: "allowed-uid",
+      email: "user@allowed.gov.jp",
+      role: "staff",
+      staffId: "allowed-uid",
+    });
+
+    process.env.ALLOWED_EMAIL_DOMAINS = originalEnv;
+  });
+
+  it("existing user bypasses email_verified and domain checks", async () => {
+    vi.mocked(firebaseAuth.verifyIdToken).mockResolvedValue({
+      uid: "existing-uid",
+      email: "existing@notallowed.com",
+      email_verified: false,
+    } as never);
+
+    const staffDoc = {
+      id: "existing-staff-001",
+      data: () => ({ role: "staff", name: "Existing", email: "existing@notallowed.com" }),
+    };
+    const mockGet = vi.fn().mockResolvedValue({ empty: false, docs: [staffDoc] });
+    const mockLimit = vi.fn().mockReturnValue({ get: mockGet });
+    const mockWhere = vi.fn().mockReturnValue({ limit: mockLimit });
+    vi.mocked(firestore.collection).mockReturnValue({ where: mockWhere } as never);
+
+    const { req, res, next } = mockReqResNext("Bearer existing-token");
+
+    await requireAuth(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(req.user).toEqual({
+      uid: "existing-uid",
+      email: "existing@notallowed.com",
+      role: "staff",
+      staffId: "existing-staff-001",
+    });
   });
 
   it("auto-provisions staff document on first login (idempotent create)", async () => {

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -2,9 +2,10 @@ import { Request, Response, NextFunction } from "express";
 import { firebaseAuth } from "../config.js";
 import { firestore } from "../config.js";
 
-const allowedDomains = process.env.ALLOWED_EMAIL_DOMAINS
-  ? process.env.ALLOWED_EMAIL_DOMAINS.split(",").map((d) => d.trim().toLowerCase())
+const parsedDomains = process.env.ALLOWED_EMAIL_DOMAINS
+  ? process.env.ALLOWED_EMAIL_DOMAINS.split(",").map((d) => d.trim().toLowerCase()).filter((d) => d.length > 0)
   : null;
+const allowedDomains = parsedDomains && parsedDomains.length > 0 ? parsedDomains : null;
 
 if (!allowedDomains) {
   console.warn("WARNING: ALLOWED_EMAIL_DOMAINS is not set. Any authenticated user can auto-provision as staff.");
@@ -52,11 +53,15 @@ export async function requireAuth(req: Request, res: Response, next: NextFunctio
 
     if (staffQuery.empty) {
       // 未登録ユーザーのアクセス制御
+      if (!decoded.email) {
+        res.status(403).json({ error: "Email is required for auto-provisioning" });
+        return;
+      }
       if (!decoded.email_verified) {
         res.status(403).json({ error: "Email not verified" });
         return;
       }
-      if (!isEmailAllowed(decoded.email ?? "")) {
+      if (!isEmailAllowed(decoded.email)) {
         res.status(403).json({ error: "Access denied: email domain not allowed" });
         return;
       }


### PR DESCRIPTION
## Summary
- email未設定ユーザーの自動登録を明示的に403で拒否
- `ALLOWED_EMAIL_DOMAINS`が空文字・空白のみの場合を未設定扱いに正規化（意図しない全ブロック防止）
- Codexセカンドオピニオン実施、既存Issue（#30, #31, #18）で対応すべき項目を確認

## テスト追加（+6件、合計74テスト）
| テスト | 検証内容 |
|--------|---------|
| email_verified未定義 | undefinedも403で拒否 |
| email未定義 | メールなしユーザーを403で拒否 |
| 空ALLOWED_EMAIL_DOMAINS | `",,"` → 未設定扱い（fail-open） |
| 空Bearerトークン | `"Bearer "` → 401 |
| 許可ドメイン一致 | env設定+一致ドメイン → auto-provision成功 |
| 既存ユーザーバイパス | 未検証email+許可外ドメインでもログイン可 |

## Test plan
- [x] BE: 74テスト全パス
- [x] ESLint通過
- [x] Codexセカンドオピニオン完了
- [ ] CI通過確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced email validation and domain-based authorization checks
  * Improved error handling for missing or invalid email credentials during authentication

* **Tests**
  * Added comprehensive test coverage for authentication middleware, including edge cases for auto-provisioning, domain validation, and role assignment scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->