### PR TITLE
fix: Zod v4によるAPI入力検証の強化

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "express": "^5.2.1",
         "firebase-admin": "^13.7.0",
         "multer": "^2.1.1",
-        "typescript-eslint": "^8.56.1"
+        "typescript-eslint": "^8.56.1",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@types/express": "^5.0.6",
@@ -6121,6 +6122,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "express": "^5.2.1",
     "firebase-admin": "^13.7.0",
     "multer": "^2.1.1",
-    "typescript-eslint": "^8.56.1"
+    "typescript-eslint": "^8.56.1",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/express": "^5.0.6",

--- a/src/routes/cases.ts
+++ b/src/routes/cases.ts
@@ -1,12 +1,25 @@
 import { Router, Request, Response } from "express";
 import multer from "multer";
+import type { ZodType } from "zod";
 import * as caseRepo from "../repositories/case-repository.js";
 import * as consultationRepo from "../repositories/consultation-repository.js";
 import * as supportMenuRepo from "../repositories/support-menu-repository.js";
 import { analyzeConsultation, analyzeAudioConsultation } from "../services/ai.js";
-import { ConsultationType, SUPPORTED_AUDIO_MIME_TYPES } from "../types.js";
+import { SUPPORTED_AUDIO_MIME_TYPES } from "../types.js";
 import { Timestamp } from "@google-cloud/firestore";
 import { requireCaseAccess } from "../middleware/authz.js";
+import {
+  createCaseSchema,
+  updateCaseStatusSchema,
+  createConsultationSchema,
+  createAudioConsultationSchema,
+} from "../schemas/case.js";
+
+function validate<T>(schema: ZodType<T>, data: unknown): { success: true; data: T } | { success: false; error: string } {
+  const result = schema.safeParse(data);
+  if (result.success) return { success: true, data: result.data };
+  return { success: false, error: result.error.issues.map((e) => e.message).join(", ") };
+}
 
 const upload = multer({
   storage: multer.memoryStorage(),
@@ -28,18 +41,19 @@ export const casesRouter = Router();
 
 // POST /api/cases - ケース作成（assignedStaffIdはreq.userから強制）
 casesRouter.post("/", async (req: Request, res: Response) => {
+  const parsed = validate(createCaseSchema, req.body);
+  if (!parsed.success) {
+    res.status(400).json({ error: parsed.error });
+    return;
+  }
   try {
-    const { clientName, clientId, dateOfBirth, householdInfo, incomeInfo } = req.body;
-    if (!clientName || !clientId) {
-      res.status(400).json({ error: "clientName, clientId are required" });
-      return;
-    }
+    const data = parsed.data;
     const created = await caseRepo.createCase({
-      clientName,
-      clientId,
-      dateOfBirth: Timestamp.fromDate(new Date(dateOfBirth)),
-      householdInfo: householdInfo ?? {},
-      incomeInfo: incomeInfo ?? {},
+      clientName: data.clientName,
+      clientId: data.clientId,
+      dateOfBirth: Timestamp.fromDate(new Date(data.dateOfBirth)),
+      householdInfo: data.householdInfo,
+      incomeInfo: data.incomeInfo,
       assignedStaffId: req.user!.staffId,
     });
     res.status(201).json(created);
@@ -82,13 +96,13 @@ casesRouter.get("/:id", requireCaseAccess, async (req: Request, res: Response) =
 
 // PATCH /api/cases/:id/status - ステータス変更（認可チェック済み）
 casesRouter.patch("/:id/status", requireCaseAccess, async (req: Request, res: Response) => {
+  const parsed = validate(updateCaseStatusSchema, req.body);
+  if (!parsed.success) {
+    res.status(400).json({ error: parsed.error });
+    return;
+  }
   try {
-    const { status } = req.body;
-    if (!status) {
-      res.status(400).json({ error: "status is required" });
-      return;
-    }
-    const updated = await caseRepo.updateCaseStatus(paramStr(req.params.id), status);
+    const updated = await caseRepo.updateCaseStatus(paramStr(req.params.id), parsed.data.status);
     res.json(updated);
   } catch (err) {
     const message = (err as Error).message;
@@ -99,25 +113,25 @@ casesRouter.patch("/:id/status", requireCaseAccess, async (req: Request, res: Re
 
 // POST /api/cases/:id/consultations - 相談記録作成 + AI分析（staffIdはreq.userから強制）
 casesRouter.post("/:id/consultations", requireCaseAccess, async (req: Request, res: Response) => {
+  const parsed = validate(createConsultationSchema, req.body);
+  if (!parsed.success) {
+    res.status(400).json({ error: parsed.error });
+    return;
+  }
   try {
     const caseId = paramStr(req.params.id);
-
-    const { content, transcript, consultationType } = req.body;
-    if (!content || !consultationType) {
-      res.status(400).json({ error: "content, consultationType are required" });
-      return;
-    }
+    const data = parsed.data;
 
     const consultation = await consultationRepo.createConsultation(caseId, {
       staffId: req.user!.staffId,
-      content,
-      transcript: transcript ?? "",
-      consultationType: consultationType as ConsultationType,
+      content: data.content,
+      transcript: data.transcript,
+      consultationType: data.consultationType,
     });
 
     // AI分析を非同期で実行（レスポンスは先に返す）
     const menus = await supportMenuRepo.listSupportMenus();
-    analyzeConsultation({ content, transcript: transcript ?? "" }, menus)
+    analyzeConsultation({ content: data.content, transcript: data.transcript }, menus)
       .then(async (aiResult) => {
         await consultationRepo.updateConsultationAIResults(
           caseId,
@@ -148,27 +162,28 @@ casesRouter.post("/:id/consultations/audio", requireCaseAccess, upload.single("a
       return;
     }
 
-    const { context, consultationType } = req.body;
-    if (!consultationType) {
-      res.status(400).json({ error: "consultationType is required" });
+    const parsed = validate(createAudioConsultationSchema, req.body);
+    if (!parsed.success) {
+      res.status(400).json({ error: parsed.error });
       return;
     }
+    const data = parsed.data;
 
     // Gemini 2.5 Flash で音声分析（文字起こし + 要約 + 支援提案を1回で）
     const menus = await supportMenuRepo.listSupportMenus();
     const aiResult = await analyzeAudioConsultation(
       file.buffer,
       file.mimetype,
-      context ?? "",
+      data.context,
       menus,
     );
 
     // 分析結果を含めて相談記録を作成
     const consultationData = {
       staffId: req.user!.staffId,
-      content: context ?? "",
+      content: data.context,
       transcript: aiResult.transcript,
-      consultationType: consultationType as ConsultationType,
+      consultationType: data.consultationType,
     };
     const consultation = await consultationRepo.createConsultation(caseId, consultationData);
 

--- a/src/schemas/case.ts
+++ b/src/schemas/case.ts
@@ -1,0 +1,36 @@
+import { z } from "zod";
+
+// 日付文字列バリデーション（YYYY-MM-DD形式 + 実在する日付）
+const dateString = z
+  .string({ error: "dateOfBirth must be a string" })
+  .regex(/^\d{4}-\d{2}-\d{2}$/, { error: "Date must be YYYY-MM-DD format" })
+  .refine((val) => !isNaN(new Date(val).getTime()), { error: "Invalid date" });
+
+export const createCaseSchema = z.object({
+  clientName: z.string({ error: "clientName is required" }).min(1, { error: "clientName is required" }).max(100),
+  clientId: z.string({ error: "clientId is required" }).min(1, { error: "clientId is required" }).max(100),
+  dateOfBirth: dateString,
+  householdInfo: z.record(z.string(), z.unknown()).optional().default({}),
+  incomeInfo: z.record(z.string(), z.unknown()).optional().default({}),
+});
+
+export const updateCaseStatusSchema = z.object({
+  status: z.enum(["active", "referred", "closed"], {
+    error: "status must be one of: active, referred, closed",
+  }),
+});
+
+export const consultationTypeEnum = z.enum(["visit", "counter", "phone", "online"], {
+  error: "consultationType must be one of: visit, counter, phone, online",
+});
+
+export const createConsultationSchema = z.object({
+  content: z.string({ error: "content is required" }).min(1, { error: "content is required" }).max(50000),
+  consultationType: consultationTypeEnum,
+  transcript: z.string().max(100000).optional().default(""),
+});
+
+export const createAudioConsultationSchema = z.object({
+  consultationType: consultationTypeEnum,
+  context: z.string().max(10000).optional().default(""),
+});

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -232,6 +232,42 @@ describe("POST /api/cases", () => {
     expect(res.status).toBe(500);
     expect(res.body.error).toBe("Firestore unavailable");
   });
+
+  it("returns 400 for invalid dateOfBirth format", async () => {
+    const res = await request(app).post("/api/cases").send({
+      clientName: "テスト",
+      clientId: "client-001",
+      dateOfBirth: "not-a-date",
+    });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("Date must be YYYY-MM-DD format");
+  });
+
+  it("returns 400 for impossible date (2025-13-45)", async () => {
+    const res = await request(app).post("/api/cases").send({
+      clientName: "テスト",
+      clientId: "client-001",
+      dateOfBirth: "2025-13-45",
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when clientName is empty string", async () => {
+    const res = await request(app).post("/api/cases").send({
+      clientName: "",
+      clientId: "client-001",
+      dateOfBirth: "1990-01-01",
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when dateOfBirth is missing", async () => {
+    const res = await request(app).post("/api/cases").send({
+      clientName: "テスト",
+      clientId: "client-001",
+    });
+    expect(res.status).toBe(400);
+  });
 });
 
 describe("GET /api/cases", () => {
@@ -308,7 +344,7 @@ describe("PATCH /api/cases/:id/status", () => {
 
     const res = await request(app).patch("/api/cases/case-1/status").send({});
     expect(res.status).toBe(400);
-    expect(res.body.error).toContain("required");
+    expect(res.body.error).toContain("status must be one of");
   });
 
   it("returns 404 if case not found", async () => {
@@ -323,6 +359,14 @@ describe("PATCH /api/cases/:id/status", () => {
 
     const res = await request(app).patch("/api/cases/case-other/status").send({ status: "closed" });
     expect(res.status).toBe(403);
+  });
+
+  it("returns 400 for invalid status enum value", async () => {
+    vi.mocked(caseRepo.getCase).mockResolvedValue(MOCK_CASE);
+
+    const res = await request(app).patch("/api/cases/case-1/status").send({ status: "invalid_status" });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("status must be one of");
   });
 });
 
@@ -395,6 +439,41 @@ describe("POST /api/cases/:id/consultations", () => {
     });
     expect(res.status).toBe(500);
     expect(res.body.error).toBe("DB connection failed");
+  });
+
+  it("returns 400 for invalid consultationType", async () => {
+    vi.mocked(caseRepo.getCase).mockResolvedValue(MOCK_CASE);
+
+    const res = await request(app).post("/api/cases/case-1/consultations").send({
+      content: "テスト",
+      consultationType: "email",
+    });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("consultationType must be one of");
+  });
+
+  it("accepts online consultationType", async () => {
+    vi.mocked(caseRepo.getCase).mockResolvedValue(MOCK_CASE);
+    vi.mocked(consultationRepo.createConsultation).mockResolvedValue({
+      id: "cons-2",
+      caseId: "case-1",
+      staffId: "staff-1",
+      content: "オンライン相談内容",
+      transcript: "",
+      summary: "",
+      suggestedSupports: [],
+      consultationType: "online",
+      createdAt: NOW,
+      updatedAt: NOW,
+    });
+    vi.mocked(supportMenuRepo.listSupportMenus).mockResolvedValue([]);
+    vi.mocked(analyzeConsultation).mockResolvedValue({ summary: "要約", suggestedSupports: [] });
+
+    const res = await request(app).post("/api/cases/case-1/consultations").send({
+      content: "オンライン相談内容",
+      consultationType: "online",
+    });
+    expect(res.status).toBe(201);
   });
 });
 
@@ -481,6 +560,18 @@ describe("POST /api/cases/:id/consultations/audio", () => {
       .attach("audio", Buffer.from("fake"), { filename: "test.wav", contentType: "audio/wav" });
 
     expect(res.status).toBe(403);
+  });
+
+  it("returns 400 for invalid consultationType in audio upload", async () => {
+    vi.mocked(caseRepo.getCase).mockResolvedValue(MOCK_CASE);
+
+    const res = await request(app)
+      .post("/api/cases/case-1/consultations/audio")
+      .field("consultationType", "invalid_type")
+      .attach("audio", Buffer.from("fake"), { filename: "test.wav", contentType: "audio/wav" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("consultationType must be one of");
   });
 });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,7 +44,7 @@ export interface Consultation {
   updatedAt: Timestamp;
 }
 
-export type ConsultationType = "visit" | "counter" | "phone";
+export type ConsultationType = "visit" | "counter" | "phone" | "online";
 
 export interface SuggestedSupport {
   menuId: string;


### PR DESCRIPTION
## Summary
- Zod v4スキーマで全POST/PATCHエンドポイントのリクエストボディをバリデーション
- 不正入力（無効な日付形式、不正なenum値、必須フィールド欠落）が500→400で返るように改善
- ConsultationTypeに"online"を追加（FE-BE契約不整合を修正）
- safeParse パターンでESM互換性を確保

## 変更内容
| ファイル | 変更 |
|---------|------|
| `src/schemas/case.ts` | Zod v4スキーマ定義（新規） |
| `src/routes/cases.ts` | 全ハンドラにバリデーション適用 |
| `src/types.ts` | ConsultationType に "online" 追加 |
| `src/server.test.ts` | バリデーションテスト8件追加 |
| `package.json` | zod v4.3.6 追加 |

## バリデーション対象

| エンドポイント | 検証内容 |
|---------------|---------|
| POST /api/cases | clientName/clientId必須, dateOfBirth YYYY-MM-DD形式+実在日付 |
| PATCH /api/cases/:id/status | status enum (active/referred/closed) |
| POST /api/cases/:id/consultations | content必須, consultationType enum |
| POST /api/cases/:id/consultations/audio | consultationType enum |

## Test plan
- [x] BE: 82テスト全パス（バリデーションテスト8件追加）
- [x] FE: 57テスト全パス（既存テスト影響なし）
- [x] TypeScript型チェック通過
- [x] ESLint通過
- [ ] CI通過確認

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for "online" consultation type alongside existing visit, counter, and phone options.
  * Implemented input validation across all API endpoints with descriptive error messages.

* **Bug Fixes**
  * Enhanced error handling and response consistency across case and consultation management endpoints.

* **Tests**
  * Expanded test coverage for validation scenarios and error handling paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->