### PR TITLE
security: verifyIdTokenのrevokeチェック + disabledユーザー拒否

### DIFF
--- a/src/middleware/auth.test.ts
+++ b/src/middleware/auth.test.ts
@@ -4,6 +4,7 @@ import { Request, Response, NextFunction } from "express";
 vi.mock("../config.js", () => ({
   firebaseAuth: {
     verifyIdToken: vi.fn(),
+    getUser: vi.fn(),
   },
   firestore: {
     collection: vi.fn(),
@@ -27,6 +28,9 @@ function mockReqResNext(authHeader?: string) {
 
 beforeEach(() => {
   vi.mocked(firebaseAuth.verifyIdToken).mockReset();
+  vi.mocked(firebaseAuth.getUser).mockReset();
+  // Default: user is not disabled
+  vi.mocked(firebaseAuth.getUser).mockResolvedValue({ disabled: false } as never);
 });
 
 describe("requireAuth middleware", () => {
@@ -146,7 +150,7 @@ describe("requireAuth middleware", () => {
 
     vi.resetModules();
     vi.mock("../config.js", () => ({
-      firebaseAuth: { verifyIdToken: vi.fn() },
+      firebaseAuth: { verifyIdToken: vi.fn(), getUser: vi.fn() },
       firestore: { collection: vi.fn() },
     }));
     const { requireAuth: freshRequireAuth } = await import("./auth.js");
@@ -157,6 +161,7 @@ describe("requireAuth middleware", () => {
       email: "user@anydomain.com",
       email_verified: true,
     } as never);
+    vi.mocked(freshFirebaseAuth.getUser).mockResolvedValue({ disabled: false } as never);
 
     const mockCreate = vi.fn().mockResolvedValue(undefined);
     const mockDoc = vi.fn().mockReturnValue({ id: "empty-env-uid", create: mockCreate });
@@ -199,7 +204,7 @@ describe("requireAuth middleware", () => {
     // Re-import to pick up env change
     vi.resetModules();
     vi.mock("../config.js", () => ({
-      firebaseAuth: { verifyIdToken: vi.fn() },
+      firebaseAuth: { verifyIdToken: vi.fn(), getUser: vi.fn() },
       firestore: { collection: vi.fn() },
     }));
     const { requireAuth: freshRequireAuth } = await import("./auth.js");
@@ -210,6 +215,7 @@ describe("requireAuth middleware", () => {
       email: "blocked@notallowed.com",
       email_verified: true,
     } as never);
+    vi.mocked(freshFirebaseAuth.getUser).mockResolvedValue({ disabled: false } as never);
 
     const mockGet = vi.fn().mockResolvedValue({ empty: true, docs: [] });
     const mockLimit = vi.fn().mockReturnValue({ get: mockGet });
@@ -233,7 +239,7 @@ describe("requireAuth middleware", () => {
 
     vi.resetModules();
     vi.mock("../config.js", () => ({
-      firebaseAuth: { verifyIdToken: vi.fn() },
+      firebaseAuth: { verifyIdToken: vi.fn(), getUser: vi.fn() },
       firestore: { collection: vi.fn() },
     }));
     const { requireAuth: freshRequireAuth } = await import("./auth.js");
@@ -244,6 +250,7 @@ describe("requireAuth middleware", () => {
       email: "user@allowed.gov.jp",
       email_verified: true,
     } as never);
+    vi.mocked(freshFirebaseAuth.getUser).mockResolvedValue({ disabled: false } as never);
 
     const mockCreate = vi.fn().mockResolvedValue(undefined);
     const mockDoc = vi.fn().mockReturnValue({ id: "allowed-uid", create: mockCreate });
@@ -461,6 +468,40 @@ describe("requireAuth middleware", () => {
       staffId: "staff-001",
     });
     expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when token has been revoked", async () => {
+    const revokedErr = new Error("Firebase ID token has been revoked");
+    (revokedErr as Error & { code: string }).code = "auth/id-token-revoked";
+    vi.mocked(firebaseAuth.verifyIdToken).mockRejectedValue(revokedErr);
+
+    const { req, res, next } = mockReqResNext("Bearer revoked-token");
+
+    await requireAuth(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ error: "Token has been revoked" });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when user account is disabled", async () => {
+    vi.mocked(firebaseAuth.verifyIdToken).mockResolvedValue({
+      uid: "disabled-uid",
+      email: "disabled@example.com",
+    } as never);
+
+    vi.mocked(firebaseAuth.getUser).mockResolvedValue({
+      uid: "disabled-uid",
+      disabled: true,
+    } as never);
+
+    const { req, res, next } = mockReqResNext("Bearer disabled-user-token");
+
+    await requireAuth(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ error: "User account is disabled" });
+    expect(next).not.toHaveBeenCalled();
   });
 
   it("sets admin role from staff document", async () => {

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -26,17 +26,32 @@ export async function requireAuth(req: Request, res: Response, next: NextFunctio
 
   const idToken = authHeader.slice(7);
 
-  // Step 1: Firebase IDトークン検証（失敗 → 401）
+  // Step 1: Firebase IDトークン検証（revoke チェック有効、失敗 → 401）
   let decoded;
   try {
-    decoded = await firebaseAuth.verifyIdToken(idToken);
+    decoded = await firebaseAuth.verifyIdToken(idToken, true);
   } catch (err) {
+    const code = (err as Error & { code?: string }).code;
     const message = (err as Error).message;
-    if (message.includes("expired") || message.includes("Decoding Firebase ID token failed")) {
+    if (code === "auth/id-token-revoked" || message.includes("revoked")) {
+      res.status(401).json({ error: "Token has been revoked" });
+    } else if (message.includes("expired") || message.includes("Decoding Firebase ID token failed")) {
       res.status(401).json({ error: "Invalid or expired token" });
     } else {
       res.status(401).json({ error: "Authentication failed" });
     }
+    return;
+  }
+
+  // Step 1.5: ユーザーアカウントの無効化チェック
+  try {
+    const userRecord = await firebaseAuth.getUser(decoded.uid);
+    if (userRecord.disabled) {
+      res.status(401).json({ error: "User account is disabled" });
+      return;
+    }
+  } catch {
+    res.status(401).json({ error: "Authentication failed" });
     return;
   }
 

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -12,6 +12,7 @@ vi.mock("./config.js", () => ({
   },
   firebaseAuth: {
     verifyIdToken: vi.fn(),
+    getUser: vi.fn(),
   },
   PROJECT_ID: "test-project",
   REGION: "asia-northeast1",
@@ -99,6 +100,8 @@ const OTHER_STAFF_CASE = {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // Default: user is not disabled
+  vi.mocked(firebaseAuth.getUser).mockResolvedValue({ disabled: false } as never);
 });
 
 describe("GET /health", () => {


### PR DESCRIPTION
## Summary
- `verifyIdToken(idToken, true)` でトークン失効（revoke）チェックを有効化
- `getUser(uid)` でアカウント無効化（disabled）状態を検証し401で拒否
- `auth/id-token-revoked` エラーを専用メッセージで分離

## 変更内容
| ファイル | 変更 |
|---------|------|
| `src/middleware/auth.ts` | revokeチェック有効化 + disabled確認追加 |
| `src/middleware/auth.test.ts` | テスト2件追加 + getUser mock対応 |
| `src/server.test.ts` | getUser mock追加 |

## Test plan
- [x] BE: 84テスト全パス（revokeテスト + disabledテスト追加）
- [x] FE: 57テスト全パス（影響なし）
- [x] TypeScript型チェック通過
- [x] ESLint通過（BE）
- [ ] CI通過確認

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced authentication to properly detect and reject revoked Firebase ID tokens with appropriate error messaging.
  * Added account status validation to deny access from disabled user accounts.

* **Tests**
  * Extended test coverage for new authentication failure modes, including token revocation and disabled account scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->