### PR TITLE
fix: dateString検証でDate自動補正される不存在日付を拒否する

### DIFF
--- a/src/schemas/case.ts
+++ b/src/schemas/case.ts
@@ -4,7 +4,11 @@ import { z } from "zod";
 const dateString = z
   .string({ error: "dateOfBirth must be a string" })
   .regex(/^\d{4}-\d{2}-\d{2}$/, { error: "Date must be YYYY-MM-DD format" })
-  .refine((val) => !isNaN(new Date(val).getTime()), { error: "Invalid date" });
+  .refine((val) => {
+    const [y, m, d] = val.split("-").map(Number);
+    const date = new Date(y, m - 1, d);
+    return date.getFullYear() === y && date.getMonth() === m - 1 && date.getDate() === d;
+  }, { error: "Invalid date" });
 
 export const createCaseSchema = z.object({
   clientName: z.string({ error: "clientName is required" }).min(1, { error: "clientName is required" }).max(100),

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -255,6 +255,25 @@ describe("POST /api/cases", () => {
     expect(res.status).toBe(400);
   });
 
+  it("returns 400 for non-existent date that JS auto-corrects (2025-02-31)", async () => {
+    const res = await request(app).post("/api/cases").send({
+      clientName: "テスト",
+      clientId: "client-001",
+      dateOfBirth: "2025-02-31",
+    });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("Invalid date");
+  });
+
+  it("returns 400 for April 31st (2025-04-31)", async () => {
+    const res = await request(app).post("/api/cases").send({
+      clientName: "テスト",
+      clientId: "client-001",
+      dateOfBirth: "2025-04-31",
+    });
+    expect(res.status).toBe(400);
+  });
+
   it("returns 400 when clientName is empty string", async () => {
     const res = await request(app).post("/api/cases").send({
       clientName: "",


### PR DESCRIPTION
## Summary
- JSの`new Date('2025-02-31')`がMarch 3に自動補正されバリデーションを通過する問題を修正
- 年月日コンポーネント分解→Date再構築→元値と一致確認の方式に変更
- テスト2件追加（2025-02-31, 2025-04-31）

## Test plan
- [x] BE: 86テスト全パス（+2件追加）
- [x] FE: 57テスト影響なし

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)