### PR TITLE
fix: firebaseUid重複時の不定レコード採用を防止

### DIFF
--- a/src/middleware/auth.test.ts
+++ b/src/middleware/auth.test.ts
@@ -88,10 +88,11 @@ describe("requireAuth middleware", () => {
       email_verified: false,
     } as never);
 
-    const mockGet = vi.fn().mockResolvedValue({ empty: true, docs: [] });
-    const mockLimit = vi.fn().mockReturnValue({ get: mockGet });
-    const mockWhere = vi.fn().mockReturnValue({ limit: mockLimit });
-    vi.mocked(firestore.collection).mockReturnValue({ where: mockWhere } as never);
+    const mockDocGet = vi.fn().mockResolvedValue({ exists: false });
+    const mockDoc = vi.fn().mockReturnValue({ get: mockDocGet });
+    const mockQueryGet = vi.fn().mockResolvedValue({ empty: true, size: 0, docs: [] });
+    const mockWhere = vi.fn().mockReturnValue({ get: mockQueryGet });
+    vi.mocked(firestore.collection).mockReturnValue({ doc: mockDoc, where: mockWhere } as never);
 
     const { req, res, next } = mockReqResNext("Bearer unverified-token");
 
@@ -109,10 +110,11 @@ describe("requireAuth middleware", () => {
       // email_verified intentionally omitted (undefined)
     } as never);
 
-    const mockGet = vi.fn().mockResolvedValue({ empty: true, docs: [] });
-    const mockLimit = vi.fn().mockReturnValue({ get: mockGet });
-    const mockWhere = vi.fn().mockReturnValue({ limit: mockLimit });
-    vi.mocked(firestore.collection).mockReturnValue({ where: mockWhere } as never);
+    const mockDocGet = vi.fn().mockResolvedValue({ exists: false });
+    const mockDoc = vi.fn().mockReturnValue({ get: mockDocGet });
+    const mockQueryGet = vi.fn().mockResolvedValue({ empty: true, size: 0, docs: [] });
+    const mockWhere = vi.fn().mockReturnValue({ get: mockQueryGet });
+    vi.mocked(firestore.collection).mockReturnValue({ doc: mockDoc, where: mockWhere } as never);
 
     const { req, res, next } = mockReqResNext("Bearer no-verified-token");
 
@@ -130,10 +132,11 @@ describe("requireAuth middleware", () => {
       // email intentionally omitted
     } as never);
 
-    const mockGet = vi.fn().mockResolvedValue({ empty: true, docs: [] });
-    const mockLimit = vi.fn().mockReturnValue({ get: mockGet });
-    const mockWhere = vi.fn().mockReturnValue({ limit: mockLimit });
-    vi.mocked(firestore.collection).mockReturnValue({ where: mockWhere } as never);
+    const mockDocGet = vi.fn().mockResolvedValue({ exists: false });
+    const mockDoc = vi.fn().mockReturnValue({ get: mockDocGet });
+    const mockQueryGet = vi.fn().mockResolvedValue({ empty: true, size: 0, docs: [] });
+    const mockWhere = vi.fn().mockReturnValue({ get: mockQueryGet });
+    vi.mocked(firestore.collection).mockReturnValue({ doc: mockDoc, where: mockWhere } as never);
 
     const { req, res, next } = mockReqResNext("Bearer no-email-token");
 
@@ -164,10 +167,10 @@ describe("requireAuth middleware", () => {
     vi.mocked(freshFirebaseAuth.getUser).mockResolvedValue({ disabled: false } as never);
 
     const mockCreate = vi.fn().mockResolvedValue(undefined);
-    const mockDoc = vi.fn().mockReturnValue({ id: "empty-env-uid", create: mockCreate });
-    const mockGet = vi.fn().mockResolvedValue({ empty: true, docs: [] });
-    const mockLimit = vi.fn().mockReturnValue({ get: mockGet });
-    const mockWhere = vi.fn().mockReturnValue({ limit: mockLimit });
+    const mockDocGet = vi.fn().mockResolvedValue({ exists: false });
+    const mockDoc = vi.fn().mockReturnValue({ id: "empty-env-uid", get: mockDocGet, create: mockCreate });
+    const mockQueryGet = vi.fn().mockResolvedValue({ empty: true, size: 0, docs: [] });
+    const mockWhere = vi.fn().mockReturnValue({ get: mockQueryGet });
     vi.mocked(freshFirestore.collection).mockReturnValue({
       where: mockWhere,
       doc: mockDoc,
@@ -217,10 +220,11 @@ describe("requireAuth middleware", () => {
     } as never);
     vi.mocked(freshFirebaseAuth.getUser).mockResolvedValue({ disabled: false } as never);
 
-    const mockGet = vi.fn().mockResolvedValue({ empty: true, docs: [] });
-    const mockLimit = vi.fn().mockReturnValue({ get: mockGet });
-    const mockWhere = vi.fn().mockReturnValue({ limit: mockLimit });
-    vi.mocked(freshFirestore.collection).mockReturnValue({ where: mockWhere } as never);
+    const mockDocGet = vi.fn().mockResolvedValue({ exists: false });
+    const mockDoc = vi.fn().mockReturnValue({ get: mockDocGet });
+    const mockQueryGet = vi.fn().mockResolvedValue({ empty: true, size: 0, docs: [] });
+    const mockWhere = vi.fn().mockReturnValue({ get: mockQueryGet });
+    vi.mocked(freshFirestore.collection).mockReturnValue({ doc: mockDoc, where: mockWhere } as never);
 
     const { req, res, next } = mockReqResNext("Bearer blocked-token");
 
@@ -253,10 +257,10 @@ describe("requireAuth middleware", () => {
     vi.mocked(freshFirebaseAuth.getUser).mockResolvedValue({ disabled: false } as never);
 
     const mockCreate = vi.fn().mockResolvedValue(undefined);
-    const mockDoc = vi.fn().mockReturnValue({ id: "allowed-uid", create: mockCreate });
-    const mockGet = vi.fn().mockResolvedValue({ empty: true, docs: [] });
-    const mockLimit = vi.fn().mockReturnValue({ get: mockGet });
-    const mockWhere = vi.fn().mockReturnValue({ limit: mockLimit });
+    const mockDocGet = vi.fn().mockResolvedValue({ exists: false });
+    const mockDoc = vi.fn().mockReturnValue({ id: "allowed-uid", get: mockDocGet, create: mockCreate });
+    const mockQueryGet = vi.fn().mockResolvedValue({ empty: true, size: 0, docs: [] });
+    const mockWhere = vi.fn().mockReturnValue({ get: mockQueryGet });
     vi.mocked(freshFirestore.collection).mockReturnValue({
       where: mockWhere,
       doc: mockDoc,
@@ -289,10 +293,11 @@ describe("requireAuth middleware", () => {
       id: "existing-staff-001",
       data: () => ({ role: "staff", name: "Existing", email: "existing@notallowed.com" }),
     };
-    const mockGet = vi.fn().mockResolvedValue({ empty: false, docs: [staffDoc] });
-    const mockLimit = vi.fn().mockReturnValue({ get: mockGet });
-    const mockWhere = vi.fn().mockReturnValue({ limit: mockLimit });
-    vi.mocked(firestore.collection).mockReturnValue({ where: mockWhere } as never);
+    const mockDocGet = vi.fn().mockResolvedValue({ exists: false });
+    const mockDoc = vi.fn().mockReturnValue({ get: mockDocGet });
+    const mockQueryGet = vi.fn().mockResolvedValue({ empty: false, size: 1, docs: [staffDoc] });
+    const mockWhere = vi.fn().mockReturnValue({ get: mockQueryGet });
+    vi.mocked(firestore.collection).mockReturnValue({ doc: mockDoc, where: mockWhere } as never);
 
     const { req, res, next } = mockReqResNext("Bearer existing-token");
 
@@ -316,10 +321,10 @@ describe("requireAuth middleware", () => {
     } as never);
 
     const mockCreate = vi.fn().mockResolvedValue(undefined);
-    const mockDoc = vi.fn().mockReturnValue({ id: "new-uid", create: mockCreate });
-    const mockGet = vi.fn().mockResolvedValue({ empty: true, docs: [] });
-    const mockLimit = vi.fn().mockReturnValue({ get: mockGet });
-    const mockWhere = vi.fn().mockReturnValue({ limit: mockLimit });
+    const mockDocGet = vi.fn().mockResolvedValue({ exists: false });
+    const mockDoc = vi.fn().mockReturnValue({ id: "new-uid", get: mockDocGet, create: mockCreate });
+    const mockQueryGet = vi.fn().mockResolvedValue({ empty: true, size: 0, docs: [] });
+    const mockWhere = vi.fn().mockReturnValue({ get: mockQueryGet });
     vi.mocked(firestore.collection).mockReturnValue({
       where: mockWhere,
       doc: mockDoc,
@@ -354,14 +359,16 @@ describe("requireAuth middleware", () => {
     const alreadyExistsErr = new Error("Document already exists") as Error & { code: number };
     alreadyExistsErr.code = 6; // gRPC ALREADY_EXISTS
     const mockCreate = vi.fn().mockRejectedValue(alreadyExistsErr);
-    const mockDocGet = vi.fn().mockResolvedValue({
-      id: "race-uid",
-      data: () => ({ role: "staff", email: "race@example.com", name: "" }),
-    });
+    // First get() returns not found (primary lookup), second get() returns the doc (after ALREADY_EXISTS)
+    const mockDocGet = vi.fn()
+      .mockResolvedValueOnce({ exists: false })
+      .mockResolvedValueOnce({
+        id: "race-uid",
+        data: () => ({ role: "staff", email: "race@example.com", name: "" }),
+      });
     const mockDoc = vi.fn().mockReturnValue({ id: "race-uid", create: mockCreate, get: mockDocGet });
-    const mockQueryGet = vi.fn().mockResolvedValue({ empty: true, docs: [] });
-    const mockLimit = vi.fn().mockReturnValue({ get: mockQueryGet });
-    const mockWhere = vi.fn().mockReturnValue({ limit: mockLimit });
+    const mockQueryGet = vi.fn().mockResolvedValue({ empty: true, size: 0, docs: [] });
+    const mockWhere = vi.fn().mockReturnValue({ get: mockQueryGet });
     vi.mocked(firestore.collection).mockReturnValue({
       where: mockWhere,
       doc: mockDoc,
@@ -391,10 +398,10 @@ describe("requireAuth middleware", () => {
     const firestoreErr = new Error("Permission denied") as Error & { code: number };
     firestoreErr.code = 7; // gRPC PERMISSION_DENIED
     const mockCreate = vi.fn().mockRejectedValue(firestoreErr);
-    const mockDoc = vi.fn().mockReturnValue({ id: "err-uid", create: mockCreate });
-    const mockGet = vi.fn().mockResolvedValue({ empty: true, docs: [] });
-    const mockLimit = vi.fn().mockReturnValue({ get: mockGet });
-    const mockWhere = vi.fn().mockReturnValue({ limit: mockLimit });
+    const mockDocGet = vi.fn().mockResolvedValue({ exists: false });
+    const mockDoc = vi.fn().mockReturnValue({ id: "err-uid", get: mockDocGet, create: mockCreate });
+    const mockQueryGet = vi.fn().mockResolvedValue({ empty: true, size: 0, docs: [] });
+    const mockWhere = vi.fn().mockReturnValue({ get: mockQueryGet });
     vi.mocked(firestore.collection).mockReturnValue({
       where: mockWhere,
       doc: mockDoc,
@@ -419,14 +426,16 @@ describe("requireAuth middleware", () => {
     const alreadyExistsErr = new Error("Document already exists") as Error & { code: number };
     alreadyExistsErr.code = 6;
     const mockCreate = vi.fn().mockRejectedValue(alreadyExistsErr);
-    const mockDocGet = vi.fn().mockResolvedValue({
-      id: "nodata-uid",
-      data: () => undefined,
-    });
+    // First get() → not found (primary), second get() → doc with no data (ALREADY_EXISTS recovery)
+    const mockDocGet = vi.fn()
+      .mockResolvedValueOnce({ exists: false })
+      .mockResolvedValueOnce({
+        id: "nodata-uid",
+        data: () => undefined,
+      });
     const mockDoc = vi.fn().mockReturnValue({ id: "nodata-uid", create: mockCreate, get: mockDocGet });
-    const mockQueryGet = vi.fn().mockResolvedValue({ empty: true, docs: [] });
-    const mockLimit = vi.fn().mockReturnValue({ get: mockQueryGet });
-    const mockWhere = vi.fn().mockReturnValue({ limit: mockLimit });
+    const mockQueryGet = vi.fn().mockResolvedValue({ empty: true, size: 0, docs: [] });
+    const mockWhere = vi.fn().mockReturnValue({ get: mockQueryGet });
     vi.mocked(firestore.collection).mockReturnValue({
       where: mockWhere,
       doc: mockDoc,
@@ -451,10 +460,11 @@ describe("requireAuth middleware", () => {
       id: "staff-001",
       data: () => ({ role: "staff", name: "Test Staff", email: "staff@example.com" }),
     };
-    const mockGet = vi.fn().mockResolvedValue({ empty: false, docs: [staffDoc] });
-    const mockLimit = vi.fn().mockReturnValue({ get: mockGet });
-    const mockWhere = vi.fn().mockReturnValue({ limit: mockLimit });
-    vi.mocked(firestore.collection).mockReturnValue({ where: mockWhere } as never);
+    const mockDocGet = vi.fn().mockResolvedValue({ exists: false });
+    const mockDoc = vi.fn().mockReturnValue({ get: mockDocGet });
+    const mockQueryGet = vi.fn().mockResolvedValue({ empty: false, size: 1, docs: [staffDoc] });
+    const mockWhere = vi.fn().mockReturnValue({ get: mockQueryGet });
+    vi.mocked(firestore.collection).mockReturnValue({ doc: mockDoc, where: mockWhere } as never);
 
     const { req, res, next } = mockReqResNext("Bearer valid-token");
 
@@ -504,6 +514,68 @@ describe("requireAuth middleware", () => {
     expect(next).not.toHaveBeenCalled();
   });
 
+  it("returns 500 when duplicate firebaseUid records found in legacy lookup", async () => {
+    vi.mocked(firebaseAuth.verifyIdToken).mockResolvedValue({
+      uid: "dup-uid",
+      email: "dup@example.com",
+    } as never);
+
+    const staffDoc1 = { id: "staff-dup-001", data: () => ({ role: "staff" }) };
+    const staffDoc2 = { id: "staff-dup-002", data: () => ({ role: "staff" }) };
+    // doc(uid) returns not found → falls back to legacy where query
+    const mockDocGet = vi.fn().mockResolvedValue({ exists: false });
+    const mockDoc = vi.fn().mockReturnValue({ get: mockDocGet });
+    // Legacy query finds 2 duplicates → should fail closed
+    const mockQueryGet = vi.fn().mockResolvedValue({ empty: false, size: 2, docs: [staffDoc1, staffDoc2] });
+    const mockWhere = vi.fn().mockReturnValue({ get: mockQueryGet });
+    vi.mocked(firestore.collection).mockReturnValue({
+      doc: mockDoc,
+      where: mockWhere,
+    } as never);
+
+    const { req, res, next } = mockReqResNext("Bearer dup-token");
+
+    await requireAuth(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({ error: "Internal server error" });
+  });
+
+  it("uses doc(uid) as primary lookup for staff", async () => {
+    vi.mocked(firebaseAuth.verifyIdToken).mockResolvedValue({
+      uid: "direct-uid",
+      email: "direct@example.com",
+    } as never);
+
+    // doc(uid).get() returns found → should use directly without where query
+    const mockDocGet = vi.fn().mockResolvedValue({
+      exists: true,
+      id: "direct-uid",
+      data: () => ({ role: "admin", firebaseUid: "direct-uid", email: "direct@example.com" }),
+    });
+    const mockDoc = vi.fn().mockReturnValue({ get: mockDocGet });
+    const mockWhere = vi.fn();
+    vi.mocked(firestore.collection).mockReturnValue({
+      doc: mockDoc,
+      where: mockWhere,
+    } as never);
+
+    const { req, res, next } = mockReqResNext("Bearer direct-token");
+
+    await requireAuth(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(mockDoc).toHaveBeenCalledWith("direct-uid");
+    expect(mockWhere).not.toHaveBeenCalled(); // No fallback needed
+    expect(req.user).toEqual({
+      uid: "direct-uid",
+      email: "direct@example.com",
+      role: "admin",
+      staffId: "direct-uid",
+    });
+  });
+
   it("sets admin role from staff document", async () => {
     vi.mocked(firebaseAuth.verifyIdToken).mockResolvedValue({
       uid: "firebase-uid-admin",
@@ -514,10 +586,11 @@ describe("requireAuth middleware", () => {
       id: "admin-001",
       data: () => ({ role: "admin", name: "Admin", email: "admin@example.com" }),
     };
-    const mockGet = vi.fn().mockResolvedValue({ empty: false, docs: [staffDoc] });
-    const mockLimit = vi.fn().mockReturnValue({ get: mockGet });
-    const mockWhere = vi.fn().mockReturnValue({ limit: mockLimit });
-    vi.mocked(firestore.collection).mockReturnValue({ where: mockWhere } as never);
+    const mockDocGet = vi.fn().mockResolvedValue({ exists: false });
+    const mockDoc = vi.fn().mockReturnValue({ get: mockDocGet });
+    const mockQueryGet = vi.fn().mockResolvedValue({ empty: false, size: 1, docs: [staffDoc] });
+    const mockWhere = vi.fn().mockReturnValue({ get: mockQueryGet });
+    vi.mocked(firestore.collection).mockReturnValue({ doc: mockDoc, where: mockWhere } as never);
 
     const { req, res, next } = mockReqResNext("Bearer admin-token");
 

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -57,63 +57,83 @@ export async function requireAuth(req: Request, res: Response, next: NextFunctio
 
   // Step 2: Firestoreからスタッフ情報取得/作成（失敗 → 500）
   try {
-    const staffQuery = await firestore
-      .collection("staff")
-      .where("firebaseUid", "==", decoded.uid)
-      .limit(1)
-      .get();
-
+    const staffCollection = firestore.collection("staff");
     let staffId: string;
     let role: "admin" | "staff";
 
-    if (staffQuery.empty) {
-      // 未登録ユーザーのアクセス制御
-      if (!decoded.email) {
-        res.status(403).json({ error: "Email is required for auto-provisioning" });
-        return;
-      }
-      if (!decoded.email_verified) {
-        res.status(403).json({ error: "Email not verified" });
-        return;
-      }
-      if (!isEmailAllowed(decoded.email)) {
-        res.status(403).json({ error: "Access denied: email domain not allowed" });
+    // Step 2a: doc(uid) を一次ソースとして検索（新規ユーザーはuid=docId）
+    const primaryDoc = await staffCollection.doc(decoded.uid).get();
+
+    if (primaryDoc.exists) {
+      const data = primaryDoc.data()!;
+      staffId = primaryDoc.id;
+      role = (data.role as "admin" | "staff") ?? "staff";
+    } else {
+      // Step 2b: レガシー互換 — firebaseUidフィールドで検索（limit なし）
+      const legacyQuery = await staffCollection
+        .where("firebaseUid", "==", decoded.uid)
+        .get();
+
+      if (legacyQuery.size > 1) {
+        // 重複レコード検出 → fail closed
+        console.error("Duplicate staff records for firebaseUid", {
+          uid: decoded.uid,
+          count: legacyQuery.size,
+          docIds: legacyQuery.docs.map((d) => d.id),
+        });
+        res.status(500).json({ error: "Internal server error" });
         return;
       }
 
-      // Auto-provision: 初回ログイン時にstaffドキュメントを自動作成
-      // firebaseUidをドキュメントIDに使い、create()で冪等に作成（競合対策）
-      const newStaffRef = firestore.collection("staff").doc(decoded.uid);
-      try {
-        await newStaffRef.create({
-          firebaseUid: decoded.uid,
-          email: decoded.email ?? "",
-          name: decoded.name ?? "",
-          role: "staff",
-          createdAt: new Date(),
-        });
-        staffId = newStaffRef.id;
-        role = "staff";
-      } catch (provisionErr: unknown) {
-        const code = (provisionErr as { code?: number }).code;
-        if (code === 6) {
-          // ALREADY_EXISTS: 同時リクエストが先に作成済み
-          const existingDoc = await newStaffRef.get();
-          const existingData = existingDoc.data();
-          if (!existingData) {
-            throw new Error("Staff document exists but has no data");
+      if (legacyQuery.size === 1) {
+        // レガシーレコード発見
+        const staffDoc = legacyQuery.docs[0];
+        staffId = staffDoc.id;
+        role = (staffDoc.data().role as "admin" | "staff") ?? "staff";
+      } else {
+        // 未登録ユーザーのアクセス制御
+        if (!decoded.email) {
+          res.status(403).json({ error: "Email is required for auto-provisioning" });
+          return;
+        }
+        if (!decoded.email_verified) {
+          res.status(403).json({ error: "Email not verified" });
+          return;
+        }
+        if (!isEmailAllowed(decoded.email)) {
+          res.status(403).json({ error: "Access denied: email domain not allowed" });
+          return;
+        }
+
+        // Auto-provision: 初回ログイン時にstaffドキュメントを自動作成
+        // firebaseUidをドキュメントIDに使い、create()で冪等に作成（競合対策）
+        const newStaffRef = staffCollection.doc(decoded.uid);
+        try {
+          await newStaffRef.create({
+            firebaseUid: decoded.uid,
+            email: decoded.email ?? "",
+            name: decoded.name ?? "",
+            role: "staff",
+            createdAt: new Date(),
+          });
+          staffId = newStaffRef.id;
+          role = "staff";
+        } catch (provisionErr: unknown) {
+          const code = (provisionErr as { code?: number }).code;
+          if (code === 6) {
+            // ALREADY_EXISTS: 同時リクエストが先に作成済み
+            const existingDoc = await newStaffRef.get();
+            const existingData = existingDoc.data();
+            if (!existingData) {
+              throw new Error("Staff document exists but has no data");
+            }
+            staffId = existingDoc.id;
+            role = (existingData.role as "admin" | "staff") ?? "staff";
+          } else {
+            throw provisionErr;
           }
-          staffId = existingDoc.id;
-          role = (existingData.role as "admin" | "staff") ?? "staff";
-        } else {
-          throw provisionErr;
         }
       }
-    } else {
-      const staffDoc = staffQuery.docs[0];
-      const staffData = staffDoc.data();
-      staffId = staffDoc.id;
-      role = (staffData.role as "admin" | "staff") ?? "staff";
     }
 
     req.user = {

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -126,10 +126,11 @@ describe("GET /api/me", () => {
       id: "staff-me-001",
       data: () => ({ role: "admin", name: "Me", email: "me@example.com" }),
     };
-    const mockGet = vi.fn().mockResolvedValue({ empty: false, docs: [staffDoc] });
-    const mockLimit = vi.fn().mockReturnValue({ get: mockGet });
-    const mockWhere = vi.fn().mockReturnValue({ limit: mockLimit });
-    vi.mocked(firestore.collection).mockReturnValue({ where: mockWhere } as never);
+    const mockDocGet = vi.fn().mockResolvedValue({ exists: false });
+    const mockDoc = vi.fn().mockReturnValue({ get: mockDocGet });
+    const mockQueryGet = vi.fn().mockResolvedValue({ empty: false, size: 1, docs: [staffDoc] });
+    const mockWhere = vi.fn().mockReturnValue({ get: mockQueryGet });
+    vi.mocked(firestore.collection).mockReturnValue({ doc: mockDoc, where: mockWhere } as never);
 
     const res = await request(authApp)
       .get("/api/me")
@@ -158,11 +159,11 @@ describe("GET /api/me", () => {
     } as never);
 
     const mockCreate = vi.fn().mockResolvedValue(undefined);
-    const mockDoc = vi.fn().mockReturnValue({ id: "uid-new", create: mockCreate });
-    const mockGet = vi.fn().mockResolvedValue({ empty: true, docs: [] });
-    const mockLimit = vi.fn().mockReturnValue({ get: mockGet });
-    const mockWhere = vi.fn().mockReturnValue({ limit: mockLimit });
-    vi.mocked(firestore.collection).mockReturnValue({ where: mockWhere, doc: mockDoc } as never);
+    const mockDocGet = vi.fn().mockResolvedValue({ exists: false });
+    const mockDoc = vi.fn().mockReturnValue({ id: "uid-new", get: mockDocGet, create: mockCreate });
+    const mockQueryGet = vi.fn().mockResolvedValue({ empty: true, size: 0, docs: [] });
+    const mockWhere = vi.fn().mockReturnValue({ get: mockQueryGet });
+    vi.mocked(firestore.collection).mockReturnValue({ doc: mockDoc, where: mockWhere } as never);
 
     const res = await request(authApp)
       .get("/api/me")
@@ -188,10 +189,9 @@ describe("GET /api/me", () => {
       email: "err@example.com",
     } as never);
 
-    const mockGet = vi.fn().mockRejectedValue(new Error("Firestore unavailable"));
-    const mockLimit = vi.fn().mockReturnValue({ get: mockGet });
-    const mockWhere = vi.fn().mockReturnValue({ limit: mockLimit });
-    vi.mocked(firestore.collection).mockReturnValue({ where: mockWhere } as never);
+    const mockDocGet = vi.fn().mockRejectedValue(new Error("Firestore unavailable"));
+    const mockDoc = vi.fn().mockReturnValue({ get: mockDocGet });
+    vi.mocked(firestore.collection).mockReturnValue({ doc: mockDoc } as never);
 
     const res = await request(authApp)
       .get("/api/me")


### PR DESCRIPTION
## Summary
- `doc(uid)`を一次ソースとして検索し、レガシーデータのみfirebaseUidフィールド検索にフォールバック
- `limit(1)`を除去し、重複レコード検出時は500でfail closed（不定レコード採用を防止）
- テスト2件追加（重複検出、primary lookup確認）

## 変更内容
| ファイル | 変更 |
|---------|------|
| `src/middleware/auth.ts` | Step 2のスタッフ検索ロジックを doc(uid)一次→legacy fallback に再構成 |
| `src/middleware/auth.test.ts` | 全モックを新構造に対応 + テスト2件追加 |
| `src/server.test.ts` | Firestoreモックを新構造に対応 |

## Test plan
- [x] BE: 88テスト全パス（+2件追加）
- [x] FE: 57テスト影響なし

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)