### PR TITLE
fix: テキスト相談AI後処理の永続化（aiStatusフィールド追加）

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -48,6 +48,8 @@ export interface Consultation {
   summary: string;
   suggestedSupports: SuggestedSupport[];
   consultationType: "visit" | "counter" | "phone" | "online";
+  aiStatus: "pending" | "completed" | "retry_pending" | "error";
+  aiErrorMessage?: string;
   createdAt: { _seconds: number };
   updatedAt: { _seconds: number };
 }

--- a/src/repositories/consultation-repository.ts
+++ b/src/repositories/consultation-repository.ts
@@ -8,7 +8,7 @@ function consultationsRef(caseId: string) {
 
 export async function createConsultation(
   caseId: string,
-  data: Omit<Consultation, "id" | "caseId" | "createdAt" | "updatedAt" | "summary" | "suggestedSupports">,
+  data: Omit<Consultation, "id" | "caseId" | "createdAt" | "updatedAt" | "summary" | "suggestedSupports" | "aiStatus" | "aiErrorMessage" | "aiRetryCount">,
 ): Promise<Consultation> {
   const now = Timestamp.now();
   const consultationData: Omit<Consultation, "id"> = {
@@ -16,6 +16,7 @@ export async function createConsultation(
     caseId,
     summary: "",
     suggestedSupports: [],
+    aiStatus: "pending",
     createdAt: now,
     updatedAt: now,
   };
@@ -43,6 +44,23 @@ export async function updateConsultationAIResults(
   await consultationsRef(caseId).doc(consultationId).update({
     summary,
     suggestedSupports,
+    aiStatus: "completed",
     updatedAt: Timestamp.now(),
   });
+}
+
+export async function updateConsultationAIStatus(
+  caseId: string,
+  consultationId: string,
+  aiStatus: Consultation["aiStatus"],
+  aiErrorMessage?: string,
+  aiRetryCount?: number,
+): Promise<void> {
+  const update: Record<string, unknown> = {
+    aiStatus,
+    updatedAt: Timestamp.now(),
+  };
+  if (aiErrorMessage !== undefined) update.aiErrorMessage = aiErrorMessage;
+  if (aiRetryCount !== undefined) update.aiRetryCount = aiRetryCount;
+  await consultationsRef(caseId).doc(consultationId).update(update);
 }

--- a/src/routes/cases.ts
+++ b/src/routes/cases.ts
@@ -21,6 +21,13 @@ function validate<T>(schema: ZodType<T>, data: unknown): { success: true; data: 
   return { success: false, error: result.error.issues.map((e) => e.message).join(", ") };
 }
 
+function isTransientError(err: unknown): boolean {
+  const status = (err as { status?: number }).status ?? (err as { code?: number }).code;
+  if (status === 429 || status === 503) return true;
+  const message = (err as Error).message ?? "";
+  return /timeout|ETIMEDOUT|ECONNRESET|ECONNREFUSED|socket hang up/i.test(message);
+}
+
 const upload = multer({
   storage: multer.memoryStorage(),
   limits: { fileSize: 25 * 1024 * 1024 }, // 25MB（Cloud Run 32MBリクエスト上限を考慮、ヘッダ・メタデータ分のマージン確保）
@@ -141,8 +148,20 @@ casesRouter.post("/:id/consultations", requireCaseAccess, async (req: Request, r
         );
         console.log(`AI analysis completed for consultation ${consultation.id}`);
       })
-      .catch((err) => {
+      .catch(async (err) => {
         console.error(`AI analysis failed for consultation ${consultation.id}:`, err);
+        const isTransient = isTransientError(err);
+        try {
+          await consultationRepo.updateConsultationAIStatus(
+            caseId,
+            consultation.id!,
+            isTransient ? "retry_pending" : "error",
+            (err as Error).message,
+            0,
+          );
+        } catch (statusErr) {
+          console.error(`Failed to update aiStatus for consultation ${consultation.id}:`, statusErr);
+        }
       });
 
     res.status(201).json(consultation);

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -31,6 +31,7 @@ vi.mock("./repositories/consultation-repository.js", () => ({
   getConsultation: vi.fn(),
   listConsultations: vi.fn(),
   updateConsultationAIResults: vi.fn(),
+  updateConsultationAIStatus: vi.fn(),
 }));
 
 vi.mock("./repositories/support-menu-repository.js", () => ({
@@ -404,6 +405,7 @@ describe("POST /api/cases/:id/consultations", () => {
       summary: "",
       suggestedSupports: [],
       consultationType: "counter",
+      aiStatus: "pending",
       createdAt: NOW,
       updatedAt: NOW,
     });
@@ -474,6 +476,109 @@ describe("POST /api/cases/:id/consultations", () => {
     expect(res.body.error).toContain("consultationType must be one of");
   });
 
+  it("sets aiStatus to retry_pending on transient AI error (429)", async () => {
+    vi.mocked(caseRepo.getCase).mockResolvedValue(MOCK_CASE);
+    vi.mocked(consultationRepo.createConsultation).mockResolvedValue({
+      id: "cons-transient",
+      caseId: "case-1",
+      staffId: "staff-1",
+      content: "テスト",
+      transcript: "",
+      summary: "",
+      suggestedSupports: [],
+      consultationType: "counter",
+      aiStatus: "pending",
+      createdAt: NOW,
+      updatedAt: NOW,
+    });
+    vi.mocked(supportMenuRepo.listSupportMenus).mockResolvedValue([]);
+    const transientErr = new Error("Too Many Requests") as Error & { status: number };
+    transientErr.status = 429;
+    vi.mocked(analyzeConsultation).mockRejectedValue(transientErr);
+    vi.mocked(consultationRepo.updateConsultationAIStatus).mockResolvedValue();
+
+    const res = await request(app).post("/api/cases/case-1/consultations").send({
+      content: "テスト",
+      consultationType: "counter",
+    });
+    expect(res.status).toBe(201);
+
+    // fire-and-forgetのPromiseが解決するのを待つ
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(vi.mocked(consultationRepo.updateConsultationAIStatus)).toHaveBeenCalledWith(
+      "case-1",
+      "cons-transient",
+      "retry_pending",
+      "Too Many Requests",
+      0,
+    );
+  });
+
+  it("sets aiStatus to error on permanent AI error (400)", async () => {
+    vi.mocked(caseRepo.getCase).mockResolvedValue(MOCK_CASE);
+    vi.mocked(consultationRepo.createConsultation).mockResolvedValue({
+      id: "cons-permanent",
+      caseId: "case-1",
+      staffId: "staff-1",
+      content: "テスト",
+      transcript: "",
+      summary: "",
+      suggestedSupports: [],
+      consultationType: "counter",
+      aiStatus: "pending",
+      createdAt: NOW,
+      updatedAt: NOW,
+    });
+    vi.mocked(supportMenuRepo.listSupportMenus).mockResolvedValue([]);
+    const permanentErr = new Error("Invalid request") as Error & { status: number };
+    permanentErr.status = 400;
+    vi.mocked(analyzeConsultation).mockRejectedValue(permanentErr);
+    vi.mocked(consultationRepo.updateConsultationAIStatus).mockResolvedValue();
+
+    const res = await request(app).post("/api/cases/case-1/consultations").send({
+      content: "テスト",
+      consultationType: "counter",
+    });
+    expect(res.status).toBe(201);
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(vi.mocked(consultationRepo.updateConsultationAIStatus)).toHaveBeenCalledWith(
+      "case-1",
+      "cons-permanent",
+      "error",
+      "Invalid request",
+      0,
+    );
+  });
+
+  it("returns consultation with aiStatus pending", async () => {
+    vi.mocked(caseRepo.getCase).mockResolvedValue(MOCK_CASE);
+    vi.mocked(consultationRepo.createConsultation).mockResolvedValue({
+      id: "cons-status",
+      caseId: "case-1",
+      staffId: "staff-1",
+      content: "テスト",
+      transcript: "",
+      summary: "",
+      suggestedSupports: [],
+      consultationType: "counter",
+      aiStatus: "pending",
+      createdAt: NOW,
+      updatedAt: NOW,
+    });
+    vi.mocked(supportMenuRepo.listSupportMenus).mockResolvedValue([]);
+    vi.mocked(analyzeConsultation).mockResolvedValue({ summary: "要約", suggestedSupports: [] });
+
+    const res = await request(app).post("/api/cases/case-1/consultations").send({
+      content: "テスト",
+      consultationType: "counter",
+    });
+    expect(res.status).toBe(201);
+    expect(res.body.aiStatus).toBe("pending");
+  });
+
   it("accepts online consultationType", async () => {
     vi.mocked(caseRepo.getCase).mockResolvedValue(MOCK_CASE);
     vi.mocked(consultationRepo.createConsultation).mockResolvedValue({
@@ -485,6 +590,7 @@ describe("POST /api/cases/:id/consultations", () => {
       summary: "",
       suggestedSupports: [],
       consultationType: "online",
+      aiStatus: "pending",
       createdAt: NOW,
       updatedAt: NOW,
     });
@@ -521,6 +627,7 @@ describe("POST /api/cases/:id/consultations/audio", () => {
       summary: "",
       suggestedSupports: [],
       consultationType: "visit",
+      aiStatus: "pending",
       createdAt: NOW,
       updatedAt: NOW,
     });
@@ -635,6 +742,7 @@ describe("GET /api/cases/:id/consultations/:consultationId", () => {
       summary: "",
       suggestedSupports: [],
       consultationType: "counter",
+      aiStatus: "pending",
       createdAt: NOW,
       updatedAt: NOW,
     });

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,6 +30,9 @@ export const VALID_STATUS_TRANSITIONS: Record<CaseStatus, CaseStatus[]> = {
   closed: [],
 };
 
+// AI分析の処理状態
+export type AIStatus = "pending" | "completed" | "retry_pending" | "error";
+
 // 相談記録
 export interface Consultation {
   id?: string;
@@ -40,6 +43,9 @@ export interface Consultation {
   summary: string;
   suggestedSupports: SuggestedSupport[];
   consultationType: ConsultationType;
+  aiStatus: AIStatus;
+  aiErrorMessage?: string;
+  aiRetryCount?: number;
   createdAt: Timestamp;
   updatedAt: Timestamp;
 }


### PR DESCRIPTION
## Summary
- Consultation型に`aiStatus`フィールド追加（pending→completed/retry_pending/error）
- AI分析失敗時にエラー分類（transient/permanent）してaiStatusを永続化
- fire-and-forgetパターンでsummaryが空のまま残る問題を解消
- FE型も同期更新

## 状態遷移
```
[pending] ──成功──→ [completed]
    ├──transient(429,503,timeout)──→ [retry_pending]
    └──permanent(400,422,パース不能)──→ [error]
```

## 変更内容
| ファイル | 変更 |
|---------|------|
| `src/types.ts` | AIStatus型、ConsultationにaiStatus/aiErrorMessage/aiRetryCount追加 |
| `src/repositories/consultation-repository.ts` | createConsultationでaiStatus初期化、updateConsultationAIStatus関数追加 |
| `src/routes/cases.ts` | isTransientError分類、catch内でaiStatus更新 |
| `src/server.test.ts` | エラー分類テスト3件追加、モックデータにaiStatus追加 |
| `frontend/src/api.ts` | FE Consultation型にaiStatus追加 |

## Test plan
- [x] BE: 91テスト全パス（+3件追加）
- [x] FE: 57テスト全パス
- [x] TypeScript型チェック通過（BE+FE）
- [x] ESLint通過

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Consultations now display AI processing status (pending, completed, retry pending, or error).
  * Error messages shown when AI processing encounters issues.
  * Automatic retry of failed AI processing for transient errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->