### PR TITLE
test: Consultation型のFE↔BE契約テスト追加

### DIFF
--- a/frontend/src/pages/CaseDetail.test.tsx
+++ b/frontend/src/pages/CaseDetail.test.tsx
@@ -214,6 +214,26 @@ describe("CaseDetail", () => {
     expect(screen.getByText("Model overloaded")).toBeInTheDocument();
   });
 
+  it("shows error without message when aiErrorMessage is undefined", async () => {
+    const errorNoMsg = {
+      ...mockConsultations[0],
+      id: "cons-error-nomsg",
+      summary: "",
+      suggestedSupports: [],
+      aiStatus: "error" as const,
+    };
+    vi.mocked(api.getCase).mockResolvedValue(mockCase);
+    vi.mocked(api.listConsultations).mockResolvedValue([errorNoMsg]);
+    renderCaseDetail();
+
+    await waitFor(() => {
+      expect(screen.getByText("AI分析エラー")).toBeInTheDocument();
+    });
+    // aiErrorMessageがないのでエラー詳細テキストは表示されない
+    const panel = screen.getByText("AI分析エラー").closest(".ai-panel-error");
+    expect(panel?.querySelector(".ai-error-message")).toBeNull();
+  });
+
   it("shows completed AI results with aiStatus completed", async () => {
     vi.mocked(api.getCase).mockResolvedValue(mockCase);
     vi.mocked(api.listConsultations).mockResolvedValue(mockConsultations);

--- a/src/contract.test.ts
+++ b/src/contract.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expectTypeOf } from "vitest";
-import type { AuthUser } from "./types.js";
+import type { AuthUser, Consultation, ConsultationType, AIStatus, SuggestedSupport } from "./types.js";
 
 // FE側のUserInfo型を再定義（frontend/src/api.ts:UserInfoと同一であること）
 // FE側はTimestamp→{_seconds}変換があるが、UserInfoはTimestamp不使用なので直接比較可能
@@ -8,6 +8,30 @@ interface FrontendUserInfo {
   email: string;
   role: "admin" | "staff";
   staffId: string;
+}
+
+// FE側のConsultation型を再定義（frontend/src/api.ts:Consultationと同一であること）
+// Timestamp→{_seconds}変換、id必須化、aiRetryCount省略を反映
+interface FrontendConsultation {
+  id: string;
+  caseId: string;
+  staffId: string;
+  content: string;
+  transcript: string;
+  summary: string;
+  suggestedSupports: FrontendSuggestedSupport[];
+  consultationType: "visit" | "counter" | "phone" | "online";
+  aiStatus: "pending" | "completed" | "retry_pending" | "error";
+  aiErrorMessage?: string;
+  createdAt: { _seconds: number };
+  updatedAt: { _seconds: number };
+}
+
+interface FrontendSuggestedSupport {
+  menuId: string;
+  menuName: string;
+  reason: string;
+  relevanceScore: number;
 }
 
 describe("FE↔BE contract: UserInfo / AuthUser", () => {
@@ -21,5 +45,33 @@ describe("FE↔BE contract: UserInfo / AuthUser", () => {
 
   it("AuthUser has exactly the expected keys", () => {
     expectTypeOf<keyof AuthUser>().toEqualTypeOf<"uid" | "email" | "role" | "staffId">();
+  });
+});
+
+describe("FE↔BE contract: Consultation", () => {
+  it("BE ConsultationType matches FE consultationType union", () => {
+    expectTypeOf<ConsultationType>().toEqualTypeOf<FrontendConsultation["consultationType"]>();
+  });
+
+  it("BE AIStatus matches FE aiStatus union", () => {
+    expectTypeOf<AIStatus>().toEqualTypeOf<FrontendConsultation["aiStatus"]>();
+  });
+
+  it("BE SuggestedSupport is assignable to FE SuggestedSupport", () => {
+    expectTypeOf<SuggestedSupport>().toMatchTypeOf<FrontendSuggestedSupport>();
+  });
+
+  it("FE Consultation fields are subset of BE Consultation (excluding Timestamp/id differences)", () => {
+    // FEが期待するフィールドがBE型に存在することを確認
+    // Timestamp→{_seconds}変換とid optional→requiredの差異は除外
+    type ConsultationSharedFields = Pick<Consultation,
+      "caseId" | "staffId" | "content" | "transcript" | "summary" |
+      "suggestedSupports" | "consultationType" | "aiStatus" | "aiErrorMessage"
+    >;
+    type FESharedFields = Pick<FrontendConsultation,
+      "caseId" | "staffId" | "content" | "transcript" | "summary" |
+      "suggestedSupports" | "consultationType" | "aiStatus" | "aiErrorMessage"
+    >;
+    expectTypeOf<ConsultationSharedFields>().toMatchTypeOf<FESharedFields>();
   });
 });


### PR DESCRIPTION
## Summary
- Consultation型のFE↔BE契約テスト4件追加（ConsultationType, AIStatus, SuggestedSupport, 共有フィールド整合性）
- CaseDetail.test.tsxにaiStatus=error + aiErrorMessage未設定のエッジケース追加

## 変更内容
| ファイル | 変更 |
|---------|------|
| `src/contract.test.ts` | Consultation型契約テスト4件追加 |
| `frontend/src/pages/CaseDetail.test.tsx` | error+メッセージなしテスト1件追加 |

## Test plan
- [x] BE: 95テスト全パス（契約テスト4件追加）
- [x] FE: 63テスト全パス（エッジケース1件追加）
- [ ] CI通過確認

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)