### PR TITLE
fix: staffドキュメントrole保護 + AI分析完全非同期化

### DIFF
--- a/firestore/firestore.rules
+++ b/firestore/firestore.rules
@@ -35,11 +35,16 @@ service cloud.firestore {
     }
 
     // 職員情報: 読み取りは認証済み、書き込みは自分のドキュメントのみ、削除禁止
+    // roleフィールドはClient SDKから変更不可（権限昇格防止）
+    function isRoleUnchanged() {
+      return !request.resource.data.diff(resource.data).affectedKeys().hasAny(['role']);
+    }
+
     match /staff/{staffId} {
       allow read: if request.auth != null;
       allow create: if request.auth != null && request.auth.uid == staffId;
       allow update: if request.auth != null
-        && (isAdmin() || request.auth.uid == staffId);
+        && (isAdmin() || (request.auth.uid == staffId && isRoleUnchanged()));
       allow delete: if false;
     }
 

--- a/src/routes/consultations.ts
+++ b/src/routes/consultations.ts
@@ -61,9 +61,9 @@ consultationsRouter.post("/", requireCaseAccess, async (req: Request, res: Respo
       consultationType: data.consultationType,
     });
 
-    // AI分析を非同期で実行（レスポンスは先に返す）
-    const menus = await supportMenuRepo.listSupportMenus();
-    analyzeConsultation({ content: data.content, transcript: data.transcript }, menus)
+    // AI分析を完全非同期で実行（レスポンスは先に返す）
+    supportMenuRepo.listSupportMenus()
+      .then((menus) => analyzeConsultation({ content: data.content, transcript: data.transcript }, menus))
       .then(async (aiResult) => {
         await consultationRepo.updateConsultationAIResults(
           caseId,


### PR DESCRIPTION
## Summary
- **#48**: Firestoreルールで非adminユーザーのroleフィールド変更を禁止（`isRoleUnchanged()`ヘルパー追加）
- **#49**: POST /consultationsの`listSupportMenus()`をPromiseチェイン内に移動し、consultation保存後は必ず201を返すように修正

## 変更内容
| ファイル | 変更 |
|---------|------|
| `firestore/firestore.rules` | `isRoleUnchanged()`関数追加、staff updateルールに適用 |
| `src/routes/consultations.ts` | `listSupportMenus()`を非同期Promise内に移動 |

## Test plan
- [x] BE: 104テスト全パス
- [x] TypeScriptビルド通過
- [x] ESLint通過
- [ ] CI通過確認

Closes #48, Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Non-administrative staff members are now prevented from modifying their own role assignments.

* **Performance**
  * Consultation API responses are returned immediately upon creation; AI analysis processing now occurs asynchronously in the background.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->