### PR TITLE
fix: Firestoreルール強化（staff role制約 + 業務不変条件テスト）

### DIFF
--- a/firestore/firestore.rules
+++ b/firestore/firestore.rules
@@ -42,7 +42,8 @@ service cloud.firestore {
 
     match /staff/{staffId} {
       allow read: if request.auth != null;
-      allow create: if request.auth != null && request.auth.uid == staffId;
+      allow create: if request.auth != null && request.auth.uid == staffId
+        && request.resource.data.role == 'staff';
       allow update: if request.auth != null
         && (isAdmin() || (request.auth.uid == staffId && isRoleUnchanged()));
       allow delete: if false;

--- a/firestore/firestore.rules.test.ts
+++ b/firestore/firestore.rules.test.ts
@@ -144,6 +144,18 @@ describe("cases", () => {
     await assertFails(updateDoc(doc(db, "cases", "case-1"), { status: "closed" }));
   });
 
+  it("担当者はassignedStaffIdを変更できる（Express層で制御、ルール層では許可）", async () => {
+    await setupCaseData("case-1", STAFF_UID);
+    const db = staffContext(STAFF_UID).firestore();
+    await assertSucceeds(updateDoc(doc(db, "cases", "case-1"), { assignedStaffId: OTHER_STAFF_UID }));
+  });
+
+  it("adminでもケースを削除できない", async () => {
+    await setupCaseData("case-1", STAFF_UID);
+    const db = adminContext().firestore();
+    await assertFails(deleteDoc(doc(db, "cases", "case-1")));
+  });
+
   it("ケースの削除は禁止", async () => {
     await setupCaseData("case-1", STAFF_UID);
     const db = staffContext(STAFF_UID).firestore();
@@ -209,6 +221,18 @@ describe("consultations", () => {
     }));
   });
 
+  it("非担当者は相談記録を更新できない", async () => {
+    await setupConsultationData("case-1", "cons-1", STAFF_UID);
+    const db = staffContext(OTHER_STAFF_UID).firestore();
+    await assertFails(updateDoc(doc(db, "cases", "case-1", "consultations", "cons-1"), { content: "不正更新" }));
+  });
+
+  it("adminは相談記録を更新できる", async () => {
+    await setupConsultationData("case-1", "cons-1", STAFF_UID);
+    const db = adminContext().firestore();
+    await assertSucceeds(updateDoc(doc(db, "cases", "case-1", "consultations", "cons-1"), { content: "管理者更新" }));
+  });
+
   it("相談記録の削除は禁止", async () => {
     await setupConsultationData("case-1", "cons-1", STAFF_UID);
     const db = staffContext(STAFF_UID).firestore();
@@ -243,6 +267,27 @@ describe("staff", () => {
     }));
   });
 
+  it("staff作成時にrole:'admin'を指定すると拒否される（権限昇格防止）", async () => {
+    const db = staffContext(STAFF_UID).firestore();
+    await assertFails(setDoc(doc(db, "staff", STAFF_UID), {
+      name: "昇格試行",
+      email: "escalate@example.com",
+      role: "admin",
+      firebaseUid: STAFF_UID,
+      createdAt: new Date(),
+    }));
+  });
+
+  it("staff作成時にroleフィールドが未指定だと拒否される", async () => {
+    const db = staffContext(STAFF_UID).firestore();
+    await assertFails(setDoc(doc(db, "staff", STAFF_UID), {
+      name: "roleなし職員",
+      email: "norole@example.com",
+      firebaseUid: STAFF_UID,
+      createdAt: new Date(),
+    }));
+  });
+
   it("他人のstaffドキュメントは作成できない", async () => {
     const db = staffContext(STAFF_UID).firestore();
     await assertFails(setDoc(doc(db, "staff", OTHER_STAFF_UID), {
@@ -264,6 +309,12 @@ describe("staff", () => {
     await setupStaffData(STAFF_UID);
     const db = staffContext(STAFF_UID).firestore();
     await assertFails(updateDoc(doc(db, "staff", STAFF_UID), { role: "admin" }));
+  });
+
+  it("非adminがroleと他フィールドを同時更新しても拒否される", async () => {
+    await setupStaffData(STAFF_UID);
+    const db = staffContext(STAFF_UID).firestore();
+    await assertFails(updateDoc(doc(db, "staff", STAFF_UID), { name: "更新", role: "admin" }));
   });
 
   it("adminは他人のroleフィールドを変更できる", async () => {


### PR DESCRIPTION
## Summary
- **#52**: staff createでrole='staff'を強制（Client SDKからの権限昇格防止）
- **#53**: 業務不変条件テスト7件追加（ルールテスト28→35件）

## 変更内容
| ファイル | 変更 |
|---------|------|
| `firestore/firestore.rules` | staff create条件に`request.resource.data.role == 'staff'`追加 |
| `firestore/firestore.rules.test.ts` | 7テスト追加（staff 3件、cases 2件、consultations 2件） |

## 追加テスト
| テスト | 検証する不変条件 |
|--------|----------------|
| staff create role:"admin" → 拒否 | 権限昇格防止（create時） |
| staff create role未指定 → 拒否 | role必須制約 |
| 非adminがrole+name同時更新 → 拒否 | role変更の紛れ込み防止 |
| 担当者のassignedStaffId変更 → 成功 | 現状挙動の文書化（Express層で防御） |
| adminのcase削除 → 拒否 | 全ユーザーdelete禁止 |
| 非担当者の相談記録更新 → 拒否 | update権限チェック |
| adminの相談記録更新 → 成功 | admin特権確認 |

## Test plan
- [x] ルールテスト: 35件全パス（+7）
- [x] BEテスト: 104件全パス（回帰なし）
- [x] TypeScriptビルド通過
- [ ] CI通過確認

Closes #52, Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Strengthened security validation for staff account creation to prevent privilege escalation attempts.

* **Tests**
  * Added comprehensive authorization tests covering staff creation, case management, and consultation record access permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->