### PR TITLE
fix: SPAフォールバック/api吸い込み防止 + getMe失敗時の半ログイン防止

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -6,14 +6,7 @@ import { Layout } from "./components/Layout";
 import { Dashboard } from "./pages/Dashboard";
 import { CaseDetail } from "./pages/CaseDetail";
 import { onAuthStateChanged } from "firebase/auth";
-
-vi.mock("./api", () => ({
-  api: {
-    listCases: vi.fn().mockResolvedValue([]),
-    getCase: vi.fn().mockResolvedValue(null),
-    listConsultations: vi.fn().mockResolvedValue([]),
-  },
-}));
+import { api } from "./api";
 
 function renderApp(path = "/") {
   return render(
@@ -58,9 +51,17 @@ describe("App routing", () => {
 });
 
 function ProtectedRoute() {
-  const { user, loading } = useAuth();
+  const { user, userInfo, loading, authError, logout } = useAuth();
   if (loading) return <div data-testid="loading">Loading</div>;
   if (!user) return <Navigate to="/login" replace />;
+  if (authError || !userInfo) {
+    return (
+      <div>
+        <p>{authError ?? "職員情報を取得できませんでした"}</p>
+        <button onClick={() => logout()}>ログアウト</button>
+      </div>
+    );
+  }
   return <div data-testid="protected">Protected</div>;
 }
 
@@ -94,6 +95,27 @@ describe("Unauthenticated routing", () => {
         getIdToken: vi.fn().mockResolvedValue("mock-token"),
       });
       return vi.fn();
+    });
+  });
+});
+
+describe("Auth error handling", () => {
+  it("shows error message when getMe fails (half-login prevention)", async () => {
+    vi.mocked(api.getMe).mockRejectedValueOnce(new Error("403 Forbidden"));
+
+    render(
+      <AuthProvider>
+        <MemoryRouter initialEntries={["/"]}>
+          <Routes>
+            <Route path="/login" element={<div data-testid="login-page">Login</div>} />
+            <Route path="/*" element={<ProtectedRoute />} />
+          </Routes>
+        </MemoryRouter>
+      </AuthProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/職員情報の取得に失敗しました/)).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,7 +6,7 @@ import { CaseDetail } from "./pages/CaseDetail";
 import { Login } from "./pages/Login";
 
 function ProtectedRoutes() {
-  const { user, loading } = useAuth();
+  const { user, userInfo, loading, authError, logout } = useAuth();
 
   if (loading) {
     return (
@@ -19,6 +19,15 @@ function ProtectedRoutes() {
 
   if (!user) {
     return <Navigate to="/login" replace />;
+  }
+
+  if (authError || !userInfo) {
+    return (
+      <div className="loading-overlay">
+        <p>{authError ?? "職員情報を取得できませんでした"}</p>
+        <button onClick={() => logout()}>ログアウト</button>
+      </div>
+    );
   }
 
   return (

--- a/src/server-static.test.ts
+++ b/src/server-static.test.ts
@@ -57,6 +57,10 @@ beforeAll(() => {
   app.get("/health", (_req, res) => res.json({ status: "ok" }));
   app.use("/api/cases", casesRouter);
   app.use("/api/support-menus", supportMenusRouter);
+  // /api で始まるパスはSPAフォールバック対象外
+  app.use("/api", (_req, res) => {
+    res.status(404).json({ error: "Not found" });
+  });
   app.use(express.static(tmpDir));
   app.get("/{*splat}", (_req, res) => {
     res.sendFile(path.join(tmpDir, "index.html"));
@@ -92,5 +96,18 @@ describe("Static file serving", () => {
     const res = await request(app).get("/assets/app.js");
     expect(res.status).toBe(200);
     expect(res.headers["content-type"]).toMatch(/javascript/);
+  });
+
+  it("returns 404 JSON for unknown /api/* paths instead of SPA fallback", async () => {
+    const res = await request(app).get("/api/nonexistent");
+    expect(res.status).toBe(404);
+    expect(res.headers["content-type"]).toMatch(/json/);
+    expect(res.body.error).toBe("Not found");
+  });
+
+  it("returns 404 JSON for /api/cases/unknown/nonexistent subpath", async () => {
+    const res = await request(app).get("/api/unknown-endpoint/sub");
+    expect(res.status).toBe(404);
+    expect(res.headers["content-type"]).toMatch(/json/);
   });
 });

--- a/src/server.ts
+++ b/src/server.ts
@@ -28,6 +28,11 @@ app.use("/api/cases", requireAuth, casesRouter);
 app.use("/api/support-menus", requireAuth, supportMenusRouter);
 app.use("/api/admin", adminRouter);
 
+// /api で始まる未知パスは404 JSON（SPAフォールバックに吸い込まれるのを防止）
+app.use("/api", (_req, res) => {
+  res.status(404).json({ error: "Not found" });
+});
+
 // Frontend static files
 const frontendDir = path.join(__dirname, "../frontend/dist");
 app.use(express.static(frontendDir));


### PR DESCRIPTION
## Summary
- **#59**: `/api/*`未知パスがSPAフォールバックで200 HTMLを返す問題を修正（404 JSONを返すハンドラ追加）
- **#60**: Firebase Auth成功 + getMe失敗時に保護画面に入れてしまう「半ログイン状態」を修正（authError/userInfoチェック追加）

## 変更内容
| ファイル | 変更 |
|---------|------|
| `src/server.ts` | `/api`未知パス用404 JSONハンドラ追加（SPA fallback前に配置） |
| `src/server-static.test.ts` | `/api/nonexistent`→404テスト2件追加 |
| `frontend/src/App.tsx` | ProtectedRoutesでauthError/userInfo状態チェック、エラー画面+ログアウトボタン表示 |
| `frontend/src/App.test.tsx` | getMe失敗時の半ログイン防止テスト追加 |

## Test plan
- [x] BE: 149テスト全パス（+2）
- [x] FE: 65テスト全パス（+1）
- [x] TypeScriptビルド通過
- [x] ESLint通過（BE）
- [ ] CI通過確認

Closes #59, Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Authentication error states now display error messages and a logout option to users.

* **Bug Fixes**
  * API routes now properly return 404 JSON responses for unknown endpoints instead of falling back to the app interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->