### PR TITLE
test: PR#62テスト品質改善（Codexレビュー指摘対応）

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,11 +1,12 @@
 import { describe, it, expect, vi } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
-import { MemoryRouter, Routes, Route, Navigate } from "react-router-dom";
-import { AuthProvider, useAuth } from "./contexts/AuthContext";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+import { AuthProvider } from "./contexts/AuthContext";
+import { ProtectedRoutes } from "./App";
 import { Layout } from "./components/Layout";
 import { Dashboard } from "./pages/Dashboard";
 import { CaseDetail } from "./pages/CaseDetail";
-import { onAuthStateChanged } from "firebase/auth";
+import { onAuthStateChanged, signOut } from "firebase/auth";
 import { api } from "./api";
 
 function renderApp(path = "/") {
@@ -50,21 +51,6 @@ describe("App routing", () => {
   });
 });
 
-function ProtectedRoute() {
-  const { user, userInfo, loading, authError, logout } = useAuth();
-  if (loading) return <div data-testid="loading">Loading</div>;
-  if (!user) return <Navigate to="/login" replace />;
-  if (authError || !userInfo) {
-    return (
-      <div>
-        <p>{authError ?? "職員情報を取得できませんでした"}</p>
-        <button onClick={() => logout()}>ログアウト</button>
-      </div>
-    );
-  }
-  return <div data-testid="protected">Protected</div>;
-}
-
 describe("Unauthenticated routing", () => {
   it("redirects to /login when user is not authenticated", async () => {
     vi.mocked(onAuthStateChanged).mockImplementation((_auth, callback) => {
@@ -77,7 +63,7 @@ describe("Unauthenticated routing", () => {
         <MemoryRouter initialEntries={["/"]}>
           <Routes>
             <Route path="/login" element={<div data-testid="login-page">Login</div>} />
-            <Route path="/*" element={<ProtectedRoute />} />
+            <Route path="/*" element={<ProtectedRoutes />} />
           </Routes>
         </MemoryRouter>
       </AuthProvider>,
@@ -108,7 +94,7 @@ describe("Auth error handling", () => {
         <MemoryRouter initialEntries={["/"]}>
           <Routes>
             <Route path="/login" element={<div data-testid="login-page">Login</div>} />
-            <Route path="/*" element={<ProtectedRoute />} />
+            <Route path="/*" element={<ProtectedRoutes />} />
           </Routes>
         </MemoryRouter>
       </AuthProvider>,
@@ -117,5 +103,49 @@ describe("Auth error handling", () => {
     await waitFor(() => {
       expect(screen.getByText(/職員情報の取得に失敗しました/)).toBeInTheDocument();
     });
+  });
+
+  it("calls logout when logout button is clicked on auth error", async () => {
+    vi.mocked(api.getMe).mockRejectedValueOnce(new Error("403 Forbidden"));
+
+    render(
+      <AuthProvider>
+        <MemoryRouter initialEntries={["/"]}>
+          <Routes>
+            <Route path="/login" element={<div data-testid="login-page">Login</div>} />
+            <Route path="/*" element={<ProtectedRoutes />} />
+          </Routes>
+        </MemoryRouter>
+      </AuthProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("ログアウト")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText("ログアウト"));
+    expect(signOut).toHaveBeenCalled();
+  });
+
+  it("shows fallback message when userInfo is null without explicit error", async () => {
+    // getMe returns null (unexpected response) — userInfo stays null, no authError set
+    vi.mocked(api.getMe).mockResolvedValueOnce(null as never);
+
+    render(
+      <AuthProvider>
+        <MemoryRouter initialEntries={["/"]}>
+          <Routes>
+            <Route path="/login" element={<div data-testid="login-page">Login</div>} />
+            <Route path="/*" element={<ProtectedRoutes />} />
+          </Routes>
+        </MemoryRouter>
+      </AuthProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("職員情報を取得できませんでした")).toBeInTheDocument();
+    });
+    // Should NOT show protected content (Dashboard)
+    expect(screen.queryByText("ケース一覧", { selector: "h1" })).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,7 +5,7 @@ import { Dashboard } from "./pages/Dashboard";
 import { CaseDetail } from "./pages/CaseDetail";
 import { Login } from "./pages/Login";
 
-function ProtectedRoutes() {
+export function ProtectedRoutes() {
   const { user, userInfo, loading, authError, logout } = useAuth();
 
   if (loading) {

--- a/src/server-static.test.ts
+++ b/src/server-static.test.ts
@@ -105,9 +105,16 @@ describe("Static file serving", () => {
     expect(res.body.error).toBe("Not found");
   });
 
-  it("returns 404 JSON for /api/cases/unknown/nonexistent subpath", async () => {
+  it("returns 404 JSON for nested unknown /api subpath", async () => {
     const res = await request(app).get("/api/unknown-endpoint/sub");
     expect(res.status).toBe(404);
     expect(res.headers["content-type"]).toMatch(/json/);
+  });
+
+  it("returns 404 JSON for POST to unknown /api/* path", async () => {
+    const res = await request(app).post("/api/nonexistent").send({ data: "test" });
+    expect(res.status).toBe(404);
+    expect(res.headers["content-type"]).toMatch(/json/);
+    expect(res.body.error).toBe("Not found");
   });
 });


### PR DESCRIPTION
## Summary
- Auth error handlingテストをテスト内複製から本番`ProtectedRoutes`コンポーネントに切替
- ログアウトボタンクリック→`signOut`呼び出しのテスト追加
- `userInfo=null`（authErrorなし）のフォールバック表示テスト追加
- POST `/api`未知パスの404 JSONテスト追加
- テスト名と実際URLの不一致を修正

## 背景
PR#62マージ後のCodexレビューで以下の指摘を受けて対応:
- [Medium] テスト内の`ProtectedRoute`複製が本番コードと乖離するリスク
- [Low] テスト名と実際URLの不一致

関連Issue: #63（signOut失敗時の張り付き対策、将来改善枠）

## Test plan
- [x] BE: 150テスト全パス
- [x] FE: 67テスト全パス（+3テスト追加）
- [x] BE lint通過
- [ ] CI通過確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for logout functionality and authentication flows.
  * Added test cases for API error handling, including 404 responses with proper error messaging.
  * Improved access control testing for fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->