### PR TITLE
fix: retryGetMe/logout連打防止

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -182,6 +182,47 @@ describe("Auth error handling", () => {
     });
   });
 
+  it("disables buttons while retryGetMe is in progress", async () => {
+    vi.mocked(api.getMe).mockRejectedValueOnce(new Error("Network error"));
+
+    render(
+      <AuthProvider>
+        <MemoryRouter initialEntries={["/"]}>
+          <Routes>
+            <Route path="/login" element={<div data-testid="login-page">Login</div>} />
+            <Route path="/*" element={<ProtectedRoutes />} />
+          </Routes>
+        </MemoryRouter>
+      </AuthProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("再試行")).toBeInTheDocument();
+    });
+
+    // Make getMe hang (never resolve) to test loading state
+    let resolveGetMe!: (value: unknown) => void;
+    vi.mocked(api.getMe).mockImplementationOnce(
+      () => new Promise((resolve) => { resolveGetMe = resolve; }),
+    );
+
+    fireEvent.click(screen.getByText("再試行"));
+
+    // Buttons should be disabled during loading
+    await waitFor(() => {
+      expect(screen.getByText("再試行")).toBeDisabled();
+      expect(screen.getByText("ログアウト")).toBeDisabled();
+    });
+
+    // Resolve to clean up
+    resolveGetMe({
+      uid: "test-uid",
+      email: "test@example.com",
+      role: "staff",
+      staffId: "test-staff-001",
+    });
+  });
+
   it("shows signOut error and force logout button when signOut fails", async () => {
     vi.mocked(api.getMe).mockRejectedValueOnce(new Error("403 Forbidden"));
     vi.mocked(signOut).mockRejectedValueOnce(new Error("Network error"));

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,7 +6,7 @@ import { CaseDetail } from "./pages/CaseDetail";
 import { Login } from "./pages/Login";
 
 export function ProtectedRoutes() {
-  const { user, userInfo, loading, authError, logoutError, logout, forceLogout, retryGetMe } = useAuth();
+  const { user, userInfo, loading, retrying, authError, logoutError, logout, forceLogout, retryGetMe } = useAuth();
 
   if (loading) {
     return (
@@ -27,8 +27,8 @@ export function ProtectedRoutes() {
         <p>{authError ?? "職員情報を取得できませんでした"}</p>
         {logoutError && <p className="error-text">{logoutError}</p>}
         <div className="auth-error-actions">
-          <button onClick={() => retryGetMe()}>再試行</button>
-          <button onClick={() => logout()}>ログアウト</button>
+          <button onClick={() => retryGetMe()} disabled={retrying}>再試行</button>
+          <button onClick={() => logout()} disabled={retrying}>ログアウト</button>
           {logoutError && <button onClick={() => forceLogout()}>強制ログアウト</button>}
         </div>
       </div>

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -7,6 +7,7 @@ interface AuthContextType {
   user: User | null;
   userInfo: UserInfo | null;
   loading: boolean;
+  retrying: boolean;
   authError: string | null;
   logoutError: string | null;
   logout: () => Promise<void>;
@@ -23,10 +24,15 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [loading, setLoading] = useState(true);
   const [authError, setAuthError] = useState<string | null>(null);
   const [logoutError, setLogoutError] = useState<string | null>(null);
+  const [retrying, setRetrying] = useState(false);
 
-  const fetchMe = async () => {
+  const fetchMe = async (isRetry = false) => {
     setAuthError(null);
-    setLoading(true);
+    if (isRetry) {
+      setRetrying(true);
+    } else {
+      setLoading(true);
+    }
     try {
       const info = await api.getMe();
       setUserInfo(info);
@@ -34,7 +40,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       setUserInfo(null);
       setAuthError(`職員情報の取得に失敗しました: ${(err as Error).message}`);
     } finally {
-      setLoading(false);
+      if (isRetry) {
+        setRetrying(false);
+      } else {
+        setLoading(false);
+      }
     }
   };
 
@@ -70,8 +80,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   };
 
   const retryGetMe = async () => {
-    if (!user) return;
-    await fetchMe();
+    if (!user || retrying) return;
+    await fetchMe(true);
   };
 
   const getIdToken = async () => {
@@ -80,7 +90,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   };
 
   return (
-    <AuthContext.Provider value={{ user, userInfo, loading, authError, logoutError, logout, forceLogout, retryGetMe, getIdToken }}>
+    <AuthContext.Provider value={{ user, userInfo, loading, retrying, authError, logoutError, logout, forceLogout, retryGetMe, getIdToken }}>
       {children}
     </AuthContext.Provider>
   );


### PR DESCRIPTION
## Summary
- AuthContextに`retrying`状態を追加（`loading`と分離してスピナー遷移を防止）
- `retryGetMe`実行中は多重呼び出しをガード
- エラー画面の「再試行」「ログアウト」ボタンを`retrying`中`disabled`に
- テスト1件追加（221件全パス: BE 150 + FE 71）

## 背景
PR#65のレビューで発見。loading中にボタン連打するとfetchMeが多重呼び出しされる問題。

## Test plan
- [x] retrying中にボタンがdisabledになることを検証
- [x] 既存テスト回帰なし (BE: 150, FE: 71)
- [ ] CI通過確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Retry and logout buttons are now properly disabled when an authentication retry is in progress, improving the user interface during loading states.

* **Tests**
  * Added test coverage for button state behavior during authentication retry operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->