### PR TITLE
fix: forceLogoutでFirebaseセッションもクリアする

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -276,7 +276,11 @@ describe("Auth error handling", () => {
       expect(screen.getByText("強制ログアウト")).toBeInTheDocument();
     });
 
+    vi.mocked(signOut).mockClear();
+
     fireEvent.click(screen.getByText("強制ログアウト"));
+
+    expect(signOut).toHaveBeenCalled();
 
     await waitFor(() => {
       expect(screen.getByTestId("login-page")).toBeInTheDocument();

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -77,6 +77,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setUserInfo(null);
     setAuthError(null);
     setLogoutError(null);
+    signOut(auth).catch(() => {});
   };
 
   const retryGetMe = async () => {


### PR DESCRIPTION
## Summary
- `forceLogout`で`signOut(auth)`を呼ぶように修正（失敗しても状態クリアは維持）
- リロードでセッション復活する問題を解消

Closes #69

## Test plan
- [x] 既存テスト71件全パス
- [x] forceLogoutでsignOutが呼ばれることを検証するアサーション追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Force logout now properly executes authentication service sign-out alongside internal state clearing.

* **Tests**
  * Enhanced logout test coverage with verification that sign-out is properly invoked, including improved mock state isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->