### PR TITLE
fix: CaseDetail API失敗時にエラーUIと再試行ボタンを表示

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -834,7 +834,9 @@ a:hover { color: var(--ai-600); }
 }
 
 .empty-state-icon { font-size: 3rem; margin-bottom: var(--space-4); opacity: 0.4; }
-.empty-state-text { font-size: var(--text-sm); margin-bottom: var(--space-5); }
+.empty-state-text { font-size: var(--text-sm); margin-bottom: var(--space-3); }
+.empty-state-subtext { font-size: var(--text-xs); color: var(--text-secondary); margin-bottom: var(--space-5); word-break: break-word; }
+.empty-state-actions { display: flex; gap: var(--space-3); justify-content: center; }
 
 .back-link {
   display: inline-flex; align-items: center; gap: var(--space-2);

--- a/frontend/src/pages/CaseDetail.test.tsx
+++ b/frontend/src/pages/CaseDetail.test.tsx
@@ -66,13 +66,36 @@ describe("CaseDetail", () => {
     expect(screen.getByText("読み込み中...")).toBeInTheDocument();
   });
 
-  it("shows error state when case not found", async () => {
-    vi.mocked(api.getCase).mockRejectedValue(new Error("Not found"));
-    vi.mocked(api.listConsultations).mockRejectedValue(new Error("Not found"));
+  it("shows error state when API fails", async () => {
+    vi.mocked(api.getCase).mockRejectedValue(new Error("Internal Server Error"));
+    vi.mocked(api.listConsultations).mockRejectedValue(new Error("Internal Server Error"));
     renderCaseDetail();
 
     await waitFor(() => {
-      expect(screen.getByText("ケースが見つかりません")).toBeInTheDocument();
+      expect(screen.getByText("データの取得に失敗しました")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Internal Server Error")).toBeInTheDocument();
+    expect(screen.getByText("再試行")).toBeInTheDocument();
+    expect(screen.getByText("一覧に戻る")).toBeInTheDocument();
+  });
+
+  it("retries loading when retry button is clicked", async () => {
+    vi.mocked(api.getCase).mockRejectedValueOnce(new Error("timeout"));
+    vi.mocked(api.listConsultations).mockRejectedValueOnce(new Error("timeout"));
+    renderCaseDetail();
+
+    await waitFor(() => {
+      expect(screen.getByText("データの取得に失敗しました")).toBeInTheDocument();
+    });
+
+    vi.mocked(api.getCase).mockResolvedValue(mockCase);
+    vi.mocked(api.listConsultations).mockResolvedValue([]);
+
+    const user = userEvent.setup();
+    await user.click(screen.getByText("再試行"));
+
+    await waitFor(() => {
+      expect(screen.getByText("山田太郎")).toBeInTheDocument();
     });
   });
 

--- a/frontend/src/pages/CaseDetail.tsx
+++ b/frontend/src/pages/CaseDetail.tsx
@@ -12,11 +12,13 @@ export function CaseDetail() {
   const [caseData, setCaseData] = useState<Case | null>(null);
   const [consultations, setConsultations] = useState<Consultation[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
   const [showNewConsultation, setShowNewConsultation] = useState(false);
 
   const loadData = useCallback(async () => {
     if (!id) return;
     setLoading(true);
+    setError(null);
     try {
       const [c, cons] = await Promise.all([
         api.getCase(id),
@@ -26,6 +28,7 @@ export function CaseDetail() {
       setConsultations(cons);
     } catch (err) {
       console.error("Failed to load case:", err);
+      setError((err as Error).message);
     } finally {
       setLoading(false);
     }
@@ -38,6 +41,22 @@ export function CaseDetail() {
       <div className="loading-overlay">
         <div className="spinner" />
         <span>読み込み中...</span>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="page-body">
+        <div className="empty-state">
+          <div className="empty-state-icon">⚠️</div>
+          <p className="empty-state-text">データの取得に失敗しました</p>
+          <p className="empty-state-subtext">{error}</p>
+          <div className="empty-state-actions">
+            <button className="btn btn-primary" onClick={loadData}>再試行</button>
+            <button className="btn btn-secondary" onClick={() => navigate("/")}>一覧に戻る</button>
+          </div>
+        </div>
       </div>
     );
   }


### PR DESCRIPTION
## Summary
- API失敗時に「ケースが見つかりません」ではなくエラーメッセージ+再試行ボタンを表示
- `error` stateを追加し、APIエラーと404を区別
- CSS: `empty-state-subtext`, `empty-state-actions` 追加

Closes #68

## Test plan
- [x] 72テスト全パス（+1テスト追加）
- [x] API失敗時のエラー表示テスト
- [x] 再試行ボタンでデータ再読み込みテスト

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Case detail page now displays error messages when data fails to load
  * Added retry button to reload case data without navigating away
  * Improved empty state styling with better visual hierarchy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->