### PR TITLE
test: 不足テスト追加 + lintエラー修正

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -86,6 +86,75 @@ describe("Unauthenticated routing", () => {
   });
 });
 
+describe("Auth fetchMe race condition", () => {
+  afterEach(() => {
+    // Restore default onAuthStateChanged mock for other tests
+    vi.mocked(onAuthStateChanged).mockImplementation((_auth, callback) => {
+      (callback as (user: unknown) => void)({
+        uid: "test-uid",
+        email: "test@example.com",
+        getIdToken: vi.fn().mockResolvedValue("mock-token"),
+      });
+      return vi.fn();
+    });
+  });
+
+  it("discards stale fetchMe response when user changes rapidly", async () => {
+    // Capture the onAuthStateChanged callback so we can fire it manually
+    let authCallback!: (user: unknown) => void;
+    vi.mocked(onAuthStateChanged).mockImplementation((_auth, callback) => {
+      authCallback = callback as (user: unknown) => void;
+      return vi.fn();
+    });
+
+    // First getMe: slow (controlled by resolveFirst)
+    let resolveFirst!: (value: UserInfo | PromiseLike<UserInfo>) => void;
+    vi.mocked(api.getMe)
+      .mockImplementationOnce(() => new Promise<UserInfo>((resolve) => { resolveFirst = resolve; }))
+      .mockResolvedValueOnce({
+        uid: "user-2",
+        email: "second@example.com",
+        role: "staff",
+        staffId: "staff-002",
+      });
+
+    render(
+      <AuthProvider>
+        <MemoryRouter initialEntries={["/"]}>
+          <Routes>
+            <Route path="/login" element={<div data-testid="login-page">Login</div>} />
+            <Route path="/*" element={<ProtectedRoutes />} />
+          </Routes>
+        </MemoryRouter>
+      </AuthProvider>,
+    );
+
+    // First user logs in — starts slow getMe
+    authCallback({ uid: "user-1", email: "first@example.com", getIdToken: vi.fn().mockResolvedValue("token-1") });
+
+    // Immediately switch to second user — starts fast getMe
+    authCallback({ uid: "user-2", email: "second@example.com", getIdToken: vi.fn().mockResolvedValue("token-2") });
+
+    // Second getMe resolves quickly
+    await waitFor(() => {
+      expect(screen.getByText("ケース一覧", { selector: "h1" })).toBeInTheDocument();
+    });
+
+    // Now resolve the stale first getMe — should be discarded
+    resolveFirst({
+      uid: "user-1",
+      email: "stale@example.com",
+      role: "staff",
+      staffId: "staff-001",
+    });
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Stale data should not appear
+    expect(screen.queryByText("stale@example.com")).not.toBeInTheDocument();
+  });
+});
+
 describe("Auth error handling", () => {
   it("shows error message when getMe fails (half-login prevention)", async () => {
     vi.mocked(api.getMe).mockRejectedValueOnce(new Error("403 Forbidden"));

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -44,16 +44,18 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       setUserInfo(null);
       setAuthError(`職員情報の取得に失敗しました: ${(err as Error).message}`);
     } finally {
-      if (requestId !== fetchIdRef.current) return;
-      if (isRetry) {
-        setRetrying(false);
-      } else {
-        setLoading(false);
+      if (requestId === fetchIdRef.current) {
+        if (isRetry) {
+          setRetrying(false);
+        } else {
+          setLoading(false);
+        }
       }
     }
   };
 
   useEffect(() => {
+    const ref = fetchIdRef;
     const unsubscribe = onAuthStateChanged(auth, async (u) => {
       setUser(u);
       setAuthError(null);
@@ -61,14 +63,14 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       if (u) {
         await fetchMe();
       } else {
-        fetchIdRef.current++;
+        ref.current++;
         setUserInfo(null);
         setLoading(false);
       }
     });
     return () => {
       unsubscribe();
-      fetchIdRef.current++;
+      ref.current++;
     };
   }, []);
 

--- a/frontend/src/pages/CaseDetail.test.tsx
+++ b/frontend/src/pages/CaseDetail.test.tsx
@@ -79,6 +79,17 @@ describe("CaseDetail", () => {
     expect(screen.getByText("一覧に戻る")).toBeInTheDocument();
   });
 
+  it("shows not found when case does not exist", async () => {
+    vi.mocked(api.getCase).mockResolvedValue(undefined as never);
+    vi.mocked(api.listConsultations).mockResolvedValue([]);
+    renderCaseDetail();
+
+    await waitFor(() => {
+      expect(screen.getByText("ケースが見つかりません")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("データの取得に失敗しました")).not.toBeInTheDocument();
+  });
+
   it("retries loading when retry button is clicked", async () => {
     vi.mocked(api.getCase).mockRejectedValueOnce(new Error("timeout"));
     vi.mocked(api.listConsultations).mockRejectedValueOnce(new Error("timeout"));


### PR DESCRIPTION
## Summary
- CaseDetail: `caseData===null`（エラーなし）の「見つかりません」パスのテスト復元
- AuthContext: race conditionテスト追加（staleレスポンス破棄検証）
- AuthContext: `no-unsafe-finally` lintエラー修正
- AuthContext: `react-hooks/exhaustive-deps` 警告修正

PR #72, #73 のレビュー不足を補完。

## Test plan
- [x] 74テスト全パス（+2テスト追加）
- [x] TypeScript通過
- [x] ESLint通過（既存警告1件のみ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)