### PR TITLE
fix: GoogleログインをsignInWithRedirectに変更 + 認証エラー画面スタイル修正

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -27,9 +27,9 @@ export function ProtectedRoutes() {
         <p>{authError ?? "職員情報を取得できませんでした"}</p>
         {logoutError && <p className="error-text">{logoutError}</p>}
         <div className="auth-error-actions">
-          <button onClick={() => retryGetMe()} disabled={retrying}>再試行</button>
-          <button onClick={() => logout()} disabled={retrying}>ログアウト</button>
-          {logoutError && <button onClick={() => forceLogout()}>強制ログアウト</button>}
+          <button className="btn btn-primary" onClick={() => retryGetMe()} disabled={retrying}>再試行</button>
+          <button className="btn btn-secondary" onClick={() => logout()} disabled={retrying}>ログアウト</button>
+          {logoutError && <button className="btn btn-ghost btn-danger" onClick={() => forceLogout()}>強制ログアウト</button>}
         </div>
       </div>
     );

--- a/frontend/src/pages/Login.test.tsx
+++ b/frontend/src/pages/Login.test.tsx
@@ -1,71 +1,72 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Login } from "./Login";
-import { signInWithPopup } from "firebase/auth";
+import { signInWithRedirect, getRedirectResult } from "firebase/auth";
 
 beforeEach(() => {
-  vi.mocked(signInWithPopup).mockReset();
+  vi.mocked(signInWithRedirect).mockReset();
+  vi.mocked(getRedirectResult).mockReset().mockResolvedValue(null);
 });
 
 describe("Login", () => {
-  it("renders Google login button", () => {
+  it("renders Google login button", async () => {
     render(<Login />);
 
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Googleアカウントでログイン" })).toBeEnabled();
+    });
     expect(screen.getByText("救護AI")).toBeInTheDocument();
     expect(screen.getByText("福祉相談業務AI支援システム")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Googleアカウントでログイン" })).toBeInTheDocument();
   });
 
-  it("calls signInWithPopup on button click", async () => {
-    vi.mocked(signInWithPopup).mockResolvedValue({} as never);
+  it("calls signInWithRedirect on button click", async () => {
+    vi.mocked(signInWithRedirect).mockResolvedValue(undefined as never);
     const user = userEvent.setup();
 
     render(<Login />);
 
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Googleアカウントでログイン" })).toBeEnabled();
+    });
+
     await user.click(screen.getByRole("button", { name: "Googleアカウントでログイン" }));
 
-    expect(signInWithPopup).toHaveBeenCalledWith(expect.anything(), expect.anything());
+    expect(signInWithRedirect).toHaveBeenCalledWith(expect.anything(), expect.anything());
   });
 
   it("shows error on login failure", async () => {
-    vi.mocked(signInWithPopup).mockRejectedValue(new Error("Network error"));
+    vi.mocked(signInWithRedirect).mockRejectedValue(new Error("Network error"));
     const user = userEvent.setup();
 
     render(<Login />);
 
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Googleアカウントでログイン" })).toBeEnabled();
+    });
+
     await user.click(screen.getByRole("button", { name: "Googleアカウントでログイン" }));
 
-    await vi.waitFor(() => {
+    await waitFor(() => {
       expect(screen.getByText("ログインに失敗しました")).toBeInTheDocument();
     });
   });
 
-  it("does not show error when popup is closed by user", async () => {
-    vi.mocked(signInWithPopup).mockRejectedValue(
-      new Error("Firebase: Error (auth/popup-closed-by-user)."),
-    );
-    const user = userEvent.setup();
+  it("shows error when getRedirectResult fails", async () => {
+    vi.mocked(getRedirectResult).mockRejectedValue(new Error("auth/internal-error"));
 
     render(<Login />);
 
-    await user.click(screen.getByRole("button", { name: "Googleアカウントでログイン" }));
-
-    await vi.waitFor(() => {
-      expect(screen.getByRole("button", { name: "Googleアカウントでログイン" })).toBeEnabled();
+    await waitFor(() => {
+      expect(screen.getByText(/ログインに失敗しました/)).toBeInTheDocument();
     });
-    expect(screen.queryByText("ログインに失敗しました")).not.toBeInTheDocument();
   });
 
-  it("disables button and shows loading state while signing in", async () => {
-    vi.mocked(signInWithPopup).mockReturnValue(new Promise(() => {}));
-    const user = userEvent.setup();
+  it("shows loading state while checking redirect result", () => {
+    vi.mocked(getRedirectResult).mockReturnValue(new Promise(() => {}));
 
     render(<Login />);
 
-    await user.click(screen.getByRole("button", { name: "Googleアカウントでログイン" }));
-
-    expect(screen.getByText("ログイン中...")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "ログイン中..." })).toBeDisabled();
   });
 });

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,26 +1,30 @@
-import { useState } from "react";
-import { signInWithPopup, GoogleAuthProvider } from "firebase/auth";
+import { useState, useEffect } from "react";
+import { signInWithRedirect, getRedirectResult, GoogleAuthProvider } from "firebase/auth";
 import { auth } from "../firebase";
 
 const googleProvider = new GoogleAuthProvider();
 
 export function Login() {
   const [error, setError] = useState("");
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let active = true;
+    getRedirectResult(auth)
+      .catch((e) => {
+        if (active) setError("ログインに失敗しました: " + (e as Error).message);
+      })
+      .finally(() => { if (active) setLoading(false); });
+    return () => { active = false; };
+  }, []);
 
   const handleGoogleLogin = async () => {
     setError("");
     setLoading(true);
     try {
-      await signInWithPopup(auth, googleProvider);
-    } catch (err) {
-      const message = (err as Error).message;
-      if (message.includes("popup-closed-by-user")) {
-        setLoading(false);
-        return;
-      }
+      await signInWithRedirect(auth, googleProvider);
+    } catch {
       setError("ログインに失敗しました");
-    } finally {
       setLoading(false);
     }
   };

--- a/frontend/src/test-setup.ts
+++ b/frontend/src/test-setup.ts
@@ -41,6 +41,8 @@ vi.mock("firebase/auth", () => ({
   signOut: vi.fn().mockResolvedValue(undefined),
   signInWithEmailAndPassword: vi.fn(),
   signInWithPopup: vi.fn(),
+  signInWithRedirect: vi.fn(),
+  getRedirectResult: vi.fn().mockResolvedValue(null),
   GoogleAuthProvider: vi.fn(),
   getAuth: vi.fn(),
 }));


### PR DESCRIPTION
## Summary
- **signInWithPopup → signInWithRedirect**: Cloud RunのデフォルトCOOPヘッダーがGoogleログインポップアップをブロックしていた問題を解消
- **認証エラー画面のボタンスタイル修正**: `btn btn-primary`/`btn-secondary`クラスを追加し、デザインシステムに準拠
- **テスト更新**: redirect方式に対応（getRedirectResult + signInWithRedirect）

## 変更ファイル
| ファイル | 変更内容 |
|---------|---------|
| `frontend/src/pages/Login.tsx` | signInWithPopup → signInWithRedirect + getRedirectResult |
| `frontend/src/pages/Login.test.tsx` | redirect方式のテストに全面更新 |
| `frontend/src/App.tsx` | 認証エラーボタンにCSSクラス追加 |
| `frontend/src/test-setup.ts` | signInWithRedirect/getRedirectResultモック追加 |

## Test plan
- [x] FE: 74テスト全パス
- [x] ESLint通過（既存警告1件のみ）
- [ ] ブラウザでの実動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated button styling across the login interface with consistent CSS classes for visual consistency.

* **Updates**
  * Google sign-in authentication flow changed from popup-based to redirect-based; loading states and error handling updated accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->