### PR TITLE
fix: COOPヘッダー緩和でGoogleログインポップアップを許可

### DIFF
--- a/frontend/src/pages/Login.test.tsx
+++ b/frontend/src/pages/Login.test.tsx
@@ -1,72 +1,71 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Login } from "./Login";
-import { signInWithRedirect, getRedirectResult } from "firebase/auth";
+import { signInWithPopup } from "firebase/auth";
 
 beforeEach(() => {
-  vi.mocked(signInWithRedirect).mockReset();
-  vi.mocked(getRedirectResult).mockReset().mockResolvedValue(null);
+  vi.mocked(signInWithPopup).mockReset();
 });
 
 describe("Login", () => {
-  it("renders Google login button", async () => {
+  it("renders Google login button", () => {
     render(<Login />);
 
-    await waitFor(() => {
-      expect(screen.getByRole("button", { name: "Googleアカウントでログイン" })).toBeEnabled();
-    });
     expect(screen.getByText("救護AI")).toBeInTheDocument();
     expect(screen.getByText("福祉相談業務AI支援システム")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Googleアカウントでログイン" })).toBeInTheDocument();
   });
 
-  it("calls signInWithRedirect on button click", async () => {
-    vi.mocked(signInWithRedirect).mockResolvedValue(undefined as never);
+  it("calls signInWithPopup on button click", async () => {
+    vi.mocked(signInWithPopup).mockResolvedValue({} as never);
     const user = userEvent.setup();
 
     render(<Login />);
 
-    await waitFor(() => {
-      expect(screen.getByRole("button", { name: "Googleアカウントでログイン" })).toBeEnabled();
-    });
-
     await user.click(screen.getByRole("button", { name: "Googleアカウントでログイン" }));
 
-    expect(signInWithRedirect).toHaveBeenCalledWith(expect.anything(), expect.anything());
+    expect(signInWithPopup).toHaveBeenCalledWith(expect.anything(), expect.anything());
   });
 
   it("shows error on login failure", async () => {
-    vi.mocked(signInWithRedirect).mockRejectedValue(new Error("Network error"));
+    vi.mocked(signInWithPopup).mockRejectedValue(new Error("Network error"));
     const user = userEvent.setup();
 
     render(<Login />);
 
-    await waitFor(() => {
-      expect(screen.getByRole("button", { name: "Googleアカウントでログイン" })).toBeEnabled();
-    });
-
     await user.click(screen.getByRole("button", { name: "Googleアカウントでログイン" }));
 
-    await waitFor(() => {
+    await vi.waitFor(() => {
       expect(screen.getByText("ログインに失敗しました")).toBeInTheDocument();
     });
   });
 
-  it("shows error when getRedirectResult fails", async () => {
-    vi.mocked(getRedirectResult).mockRejectedValue(new Error("auth/internal-error"));
+  it("does not show error when popup is closed by user", async () => {
+    vi.mocked(signInWithPopup).mockRejectedValue(
+      new Error("Firebase: Error (auth/popup-closed-by-user)."),
+    );
+    const user = userEvent.setup();
 
     render(<Login />);
 
-    await waitFor(() => {
-      expect(screen.getByText(/ログインに失敗しました/)).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Googleアカウントでログイン" }));
+
+    await vi.waitFor(() => {
+      expect(screen.getByRole("button", { name: "Googleアカウントでログイン" })).toBeEnabled();
     });
+    expect(screen.queryByText("ログインに失敗しました")).not.toBeInTheDocument();
   });
 
-  it("shows loading state while checking redirect result", () => {
-    vi.mocked(getRedirectResult).mockReturnValue(new Promise(() => {}));
+  it("disables button and shows loading state while signing in", async () => {
+    vi.mocked(signInWithPopup).mockReturnValue(new Promise(() => {}));
+    const user = userEvent.setup();
 
     render(<Login />);
 
+    await user.click(screen.getByRole("button", { name: "Googleアカウントでログイン" }));
+
+    expect(screen.getByText("ログイン中...")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "ログイン中..." })).toBeDisabled();
   });
 });

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,30 +1,26 @@
-import { useState, useEffect } from "react";
-import { signInWithRedirect, getRedirectResult, GoogleAuthProvider } from "firebase/auth";
+import { useState } from "react";
+import { signInWithPopup, GoogleAuthProvider } from "firebase/auth";
 import { auth } from "../firebase";
 
 const googleProvider = new GoogleAuthProvider();
 
 export function Login() {
   const [error, setError] = useState("");
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    let active = true;
-    getRedirectResult(auth)
-      .catch((e) => {
-        if (active) setError("ログインに失敗しました: " + (e as Error).message);
-      })
-      .finally(() => { if (active) setLoading(false); });
-    return () => { active = false; };
-  }, []);
+  const [loading, setLoading] = useState(false);
 
   const handleGoogleLogin = async () => {
     setError("");
     setLoading(true);
     try {
-      await signInWithRedirect(auth, googleProvider);
-    } catch {
+      await signInWithPopup(auth, googleProvider);
+    } catch (err) {
+      const message = (err as Error).message;
+      if (message.includes("popup-closed-by-user")) {
+        setLoading(false);
+        return;
+      }
       setError("ログインに失敗しました");
+    } finally {
       setLoading(false);
     }
   };

--- a/frontend/src/test-setup.ts
+++ b/frontend/src/test-setup.ts
@@ -41,8 +41,6 @@ vi.mock("firebase/auth", () => ({
   signOut: vi.fn().mockResolvedValue(undefined),
   signInWithEmailAndPassword: vi.fn(),
   signInWithPopup: vi.fn(),
-  signInWithRedirect: vi.fn(),
-  getRedirectResult: vi.fn().mockResolvedValue(null),
   GoogleAuthProvider: vi.fn(),
   getAuth: vi.fn(),
 }));

--- a/src/server.ts
+++ b/src/server.ts
@@ -13,6 +13,12 @@ const PORT = parseInt(process.env.PORT ?? "8080", 10);
 
 app.use(express.json());
 
+// Firebase Auth signInWithPopup に必要（デフォルトの same-origin だとポップアップがブロックされる）
+app.use((_req, res, next) => {
+  res.setHeader("Cross-Origin-Opener-Policy", "same-origin-allow-popups");
+  next();
+});
+
 // Health check
 app.get("/health", (_req, res) => {
   res.json({ status: "ok" });


### PR DESCRIPTION
## Summary
- **COOPヘッダー設定**: `Cross-Origin-Opener-Policy: same-origin-allow-popups` をExpressミドルウェアで設定。Cloud Runデフォルトの`same-origin`がFirebase Auth popupをブロックしていた
- **signInWithPopupに戻す**: signInWithRedirectはFirebase Hosting（authDomain）のデプロイが必要なため、popup方式に戻して対応
- **認証エラー画面のスタイル修正**: ボタンに`btn btn-primary`/`btn-secondary`クラスを追加

## 背景
PR#75でsignInWithRedirectに変更したが、Firebase Hostingが未セットアップのため`__/firebase/init.json`が404となりリダイレクト認証が完了しなかった。根本原因はCloud RunのCOOPヘッダーなので、サーバー側で緩和してpopup方式を復活させる。

## Test plan
- [x] FE: 74テスト全パス
- [x] BE: 150テスト全パス
- [x] ESLint通過
- [ ] ブラウザでGoogleログインpopupが動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)