### PR TITLE
fix: 担当者表示をstaffId→名前に改善、ログ出力改善

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -65,6 +65,7 @@ export interface SupportMenu {
 export interface UserInfo {
   uid: string;
   email: string;
+  name: string;
   role: "admin" | "staff";
   staffId: string;
 }

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -39,7 +39,7 @@ export function Dashboard() {
     <>
       <div className="page-header">
         <h1>ケース一覧</h1>
-        <p className="page-header-subtitle">担当: {userInfo?.staffId ?? user?.email}</p>
+        <p className="page-header-subtitle">担当: {userInfo?.name || userInfo?.email || user?.email}</p>
       </div>
       <div className="page-body">
         {authError && (
@@ -108,7 +108,9 @@ export function Dashboard() {
                       📅 {formatDate(c.createdAt)}
                     </div>
                     <div className="case-card-meta-item">
-                      👤 {c.assignedStaffId}
+                      👤 {c.assignedStaffId === userInfo?.staffId
+                        ? (userInfo.name || userInfo.email)
+                        : c.assignedStaffId}
                     </div>
                   </div>
                 </div>

--- a/frontend/src/test-setup.ts
+++ b/frontend/src/test-setup.ts
@@ -7,6 +7,7 @@ vi.mock("./api", () => ({
     getMe: vi.fn().mockResolvedValue({
       uid: "test-uid",
       email: "test@example.com",
+      name: "テスト職員",
       role: "staff",
       staffId: "test-staff-001",
     }),

--- a/src/contract.test.ts
+++ b/src/contract.test.ts
@@ -6,6 +6,7 @@ import type { AuthUser, Case, CaseStatus, Consultation, ConsultationType, AIStat
 interface FrontendUserInfo {
   uid: string;
   email: string;
+  name: string;
   role: "admin" | "staff";
   staffId: string;
 }
@@ -69,7 +70,7 @@ describe("FE↔BE contract: UserInfo / AuthUser", () => {
   });
 
   it("AuthUser has exactly the expected keys", () => {
-    expectTypeOf<keyof AuthUser>().toEqualTypeOf<"uid" | "email" | "role" | "staffId">();
+    expectTypeOf<keyof AuthUser>().toEqualTypeOf<"uid" | "email" | "name" | "role" | "staffId">();
   });
 });
 

--- a/src/middleware/auth.test.ts
+++ b/src/middleware/auth.test.ts
@@ -275,6 +275,7 @@ describe("requireAuth middleware", () => {
     expect(req.user).toEqual({
       uid: "allowed-uid",
       email: "user@allowed.gov.jp",
+      name: "",
       role: "staff",
       staffId: "allowed-uid",
     });
@@ -307,6 +308,7 @@ describe("requireAuth middleware", () => {
     expect(req.user).toEqual({
       uid: "existing-uid",
       email: "existing@notallowed.com",
+      name: "Existing",
       role: "staff",
       staffId: "existing-staff-001",
     });
@@ -344,6 +346,7 @@ describe("requireAuth middleware", () => {
     expect(req.user).toEqual({
       uid: "new-uid",
       email: "new@example.com",
+      name: "New User",
       role: "staff",
       staffId: "new-uid",
     });
@@ -383,6 +386,7 @@ describe("requireAuth middleware", () => {
     expect(req.user).toEqual({
       uid: "race-uid",
       email: "race@example.com",
+      name: "",
       role: "staff",
       staffId: "race-uid",
     });
@@ -474,6 +478,7 @@ describe("requireAuth middleware", () => {
     expect(req.user).toEqual({
       uid: "firebase-uid-1",
       email: "staff@example.com",
+      name: "Test Staff",
       role: "staff",
       staffId: "staff-001",
     });
@@ -571,6 +576,7 @@ describe("requireAuth middleware", () => {
     expect(req.user).toEqual({
       uid: "direct-uid",
       email: "direct@example.com",
+      name: "",
       role: "admin",
       staffId: "direct-uid",
     });

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -40,7 +40,7 @@ export async function requireAuth(req: Request, res: Response, next: NextFunctio
       res.status(401).json({ error: "Invalid or expired token" });
     } else {
       // auth/internal-error, auth/project-not-found, network errors, etc.
-      console.error("Token verification failed", { code, message: (err as Error).message });
+      console.error("Token verification failed", JSON.stringify({ code, message: (err as Error).message }));
       res.status(401).json({ error: "Authentication failed" });
     }
     return;
@@ -63,6 +63,7 @@ export async function requireAuth(req: Request, res: Response, next: NextFunctio
     const staffCollection = firestore.collection("staff");
     let staffId: string;
     let role: "admin" | "staff";
+    let staffName = "";
 
     // Step 2a: doc(uid) を一次ソースとして検索（新規ユーザーはuid=docId）
     const primaryDoc = await staffCollection.doc(decoded.uid).get();
@@ -71,6 +72,7 @@ export async function requireAuth(req: Request, res: Response, next: NextFunctio
       const data = primaryDoc.data()!;
       staffId = primaryDoc.id;
       role = (data.role as "admin" | "staff") ?? "staff";
+      staffName = (data.name as string) ?? "";
     } else {
       // Step 2b: レガシー互換 — firebaseUidフィールドで検索（limit なし）
       const legacyQuery = await staffCollection
@@ -93,6 +95,7 @@ export async function requireAuth(req: Request, res: Response, next: NextFunctio
         const staffDoc = legacyQuery.docs[0];
         staffId = staffDoc.id;
         role = (staffDoc.data().role as "admin" | "staff") ?? "staff";
+        staffName = (staffDoc.data().name as string) ?? "";
       } else {
         // 未登録ユーザーのアクセス制御
         if (!decoded.email) {
@@ -121,6 +124,7 @@ export async function requireAuth(req: Request, res: Response, next: NextFunctio
           });
           staffId = newStaffRef.id;
           role = "staff";
+          staffName = decoded.name ?? "";
         } catch (provisionErr: unknown) {
           const code = (provisionErr as { code?: number }).code;
           if (code === 6) {
@@ -132,6 +136,7 @@ export async function requireAuth(req: Request, res: Response, next: NextFunctio
             }
             staffId = existingDoc.id;
             role = (existingData.role as "admin" | "staff") ?? "staff";
+            staffName = (existingData.name as string) ?? "";
           } else {
             throw provisionErr;
           }
@@ -142,6 +147,7 @@ export async function requireAuth(req: Request, res: Response, next: NextFunctio
     req.user = {
       uid: decoded.uid,
       email: decoded.email ?? "",
+      name: staffName,
       role,
       staffId,
     };

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -64,8 +64,8 @@ import { Timestamp } from "@google-cloud/firestore";
 import { firebaseAuth, firestore } from "./config.js";
 
 // Fake user for route tests (routes now require req.user)
-const FAKE_USER = { uid: "test-uid", email: "test@test.com", role: "staff" as const, staffId: "staff-1" };
-const FAKE_ADMIN = { uid: "admin-uid", email: "admin@test.com", role: "admin" as const, staffId: "admin-staff" };
+const FAKE_USER = { uid: "test-uid", email: "test@test.com", name: "テスト職員", role: "staff" as const, staffId: "staff-1" };
+const FAKE_ADMIN = { uid: "admin-uid", email: "admin@test.com", name: "管理者", role: "admin" as const, staffId: "admin-staff" };
 
 const app = express();
 app.use(express.json());
@@ -150,6 +150,7 @@ describe("GET /api/me", () => {
     expect(res.body).toEqual({
       uid: "uid-me",
       email: "me@example.com",
+      name: "Me",
       role: "admin",
       staffId: "staff-me-001",
     });
@@ -183,6 +184,7 @@ describe("GET /api/me", () => {
     expect(res.body).toEqual({
       uid: "uid-new",
       email: "new@example.com",
+      name: "New User",
       role: "staff",
       staffId: "uid-new",
     });

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,7 @@ import { Timestamp } from "@google-cloud/firestore";
 export interface AuthUser {
   uid: string;
   email: string;
+  name: string;
   role: "admin" | "staff";
   staffId: string;
 }


### PR DESCRIPTION
## Summary
- `/api/me`レスポンスに`name`フィールドを追加（staffドキュメントから取得）
- ダッシュボードの担当者表示を`staffId`→`name || email`にフォールバック表示
- `console.error`のオブジェクト引数を`JSON.stringify`でCloud Runログに確実に1行出力
- IAM修正: `firebaseauth.viewer`ロールを付与済み（`verifyIdToken`のpermissionエラー解消）

## Test plan
- [x] BE: 150テスト全パス
- [x] FE: 74テスト全パス
- [x] TypeScriptビルド通過
- [x] 契約テスト更新済み
- [ ] ブラウザで担当者名表示を確認（デプロイ後）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * User names are now displayed in the Dashboard header and case metadata, replacing staff IDs and email addresses for improved readability.

* **Tests**
  * Updated test data and expectations to reflect the new user name field across authentication and API responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->