### PR TITLE
fix: Vertex AI空レスポンス時のデバッグログ追加

### DIFF
--- a/src/services/ai.ts
+++ b/src/services/ai.ts
@@ -84,7 +84,15 @@ ${buildMenuList(availableMenus)}
     },
   });
 
-  const responseText = result.response.candidates?.[0]?.content?.parts?.[0]?.text;
+  const candidate = result.response.candidates?.[0];
+  const responseText = candidate?.content?.parts?.[0]?.text;
+  if (!responseText) {
+    console.error("Vertex AI empty response", JSON.stringify({
+      finishReason: candidate?.finishReason,
+      safetyRatings: candidate?.safetyRatings,
+      candidatesCount: result.response.candidates?.length ?? 0,
+    }));
+  }
   return parseAIResponse<AISummaryResult>(responseText, ["summary", "suggestedSupports"]);
 }
 
@@ -123,6 +131,14 @@ ${buildMenuList(availableMenus)}
     },
   });
 
-  const responseText = result.response.candidates?.[0]?.content?.parts?.[0]?.text;
+  const audioCandidate = result.response.candidates?.[0];
+  const responseText = audioCandidate?.content?.parts?.[0]?.text;
+  if (!responseText) {
+    console.error("Vertex AI empty audio response", JSON.stringify({
+      finishReason: audioCandidate?.finishReason,
+      safetyRatings: audioCandidate?.safetyRatings,
+      candidatesCount: result.response.candidates?.length ?? 0,
+    }));
+  }
   return parseAIResponse<AudioAnalysisResult>(responseText, ["transcript", "summary", "suggestedSupports"]);
 }


### PR DESCRIPTION
## Summary
- E2Eスモークテストで`AI returned empty response`エラーが発生
- Vertex AIのcandidateの`finishReason`/`safetyRatings`をログ出力し、原因特定を容易に
- テキスト分析・音声分析の両方に対応

## 変更内容
| ファイル | 変更 |
|---------|------|
| `src/services/ai.ts` | 空レスポンス時にcandidate詳細をconsole.errorで出力 |

## Test plan
- [x] TypeScriptビルド通過
- [x] テスト150件全パス
- [ ] デプロイ後にAIリトライで動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and logging for AI response processing, including enhanced diagnostics for empty responses across text and audio analysis flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->