### PR TITLE
fix: AI分析のmaxOutputTokens不足で空レスポンスになる問題を修正

### DIFF
--- a/src/services/ai.ts
+++ b/src/services/ai.ts
@@ -80,7 +80,7 @@ ${buildMenuList(availableMenus)}
     generationConfig: {
       responseMimeType: "application/json",
       temperature: 0.3,
-      maxOutputTokens: 1024,
+      maxOutputTokens: 4096,
     },
   });
 


### PR DESCRIPTION
## Summary
- E2Eスモークテストで`AI returned empty response`が再現性あり
- PR#78のデバッグログで原因特定: `finishReason: "MAX_TOKENS"`
- テキスト分析の`maxOutputTokens`を1024→4096に増加（音声分析は既に4096）

## Root Cause
支援メニュー4件分のJSON（ID、名称、理由文、スコア）生成に1024トークンでは不足。
`responseMimeType: "application/json"`の場合、JSONが途中で切れると`text`が`undefined`になる。

## Test plan
- [x] TypeScriptビルド通過
- [x] テスト150件全パス
- [ ] デプロイ後に新規相談作成でAI分析成功を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Consultation analysis now supports more comprehensive and detailed responses, providing expanded output for better analysis results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->