### PR TITLE
refactor: MockMediaRecorderを共通モックに抽出

### DIFF
--- a/frontend/src/__mocks__/MockMediaRecorder.ts
+++ b/frontend/src/__mocks__/MockMediaRecorder.ts
@@ -1,0 +1,56 @@
+import { vi } from "vitest";
+
+/**
+ * Behavioral mock for MediaRecorder.
+ * - Stores stream/options on the instance
+ * - stop() fires ondataavailable + onstop synchronously (simulates real behavior)
+ *
+ * Used by: useAudioRecorder.test.ts, NewConsultationModal.test.tsx
+ */
+export class MockMediaRecorder {
+  state: "inactive" | "recording" | "paused" = "inactive";
+  ondataavailable: ((e: { data: Blob }) => void) | null = null;
+  onstop: (() => void) | null = null;
+  stream: MediaStream;
+  options?: { mimeType?: string };
+
+  constructor(stream: MediaStream, options?: { mimeType?: string }) {
+    this.stream = stream;
+    this.options = options;
+  }
+
+  start() {
+    this.state = "recording";
+  }
+
+  stop() {
+    this.state = "inactive";
+    if (this.ondataavailable) {
+      this.ondataavailable({ data: new Blob(["audio-data"], { type: "audio/webm" }) });
+    }
+    if (this.onstop) {
+      this.onstop();
+    }
+  }
+
+  pause() {
+    this.state = "paused";
+  }
+
+  resume() {
+    this.state = "recording";
+  }
+
+  static isTypeSupported(type: string): boolean {
+    return type === "audio/webm;codecs=opus";
+  }
+}
+
+/**
+ * Mock for MediaStream used in audio recording tests.
+ */
+export class MockMediaStream {
+  getTracks() {
+    return [{ stop: vi.fn() }];
+  }
+}

--- a/frontend/src/components/NewConsultationModal.test.tsx
+++ b/frontend/src/components/NewConsultationModal.test.tsx
@@ -5,22 +5,7 @@ import { NewConsultationModal } from "./NewConsultationModal";
 import { TestAuthWrapper } from "../test-utils";
 
 import { api } from "../api";
-
-// Minimal MediaRecorder mock so isSupported=true in tests
-class MockMediaRecorder {
-  state = "inactive";
-  ondataavailable: ((e: { data: Blob }) => void) | null = null;
-  onstop: (() => void) | null = null;
-  constructor(_stream: MediaStream, _options?: { mimeType?: string }) {
-    void _stream;
-    void _options;
-  }
-  start() { this.state = "recording"; }
-  stop() { this.state = "inactive"; }
-  pause() { this.state = "paused"; }
-  resume() { this.state = "recording"; }
-  static isTypeSupported(type: string) { return type === "audio/webm;codecs=opus"; }
-}
+import { MockMediaRecorder } from "../__mocks__/MockMediaRecorder";
 
 beforeEach(() => {
   vi.mocked(api.createConsultation).mockReset();

--- a/frontend/src/hooks/useAudioRecorder.test.ts
+++ b/frontend/src/hooks/useAudioRecorder.test.ts
@@ -1,54 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { renderHook, act } from "@testing-library/react";
 import { useAudioRecorder } from "./useAudioRecorder";
-
-// Mock MediaRecorder
-class MockMediaRecorder {
-  state: "inactive" | "recording" | "paused" = "inactive";
-  ondataavailable: ((e: { data: Blob }) => void) | null = null;
-  onstop: (() => void) | null = null;
-  stream: MediaStream;
-  options?: { mimeType?: string };
-
-  constructor(stream: MediaStream, options?: { mimeType?: string }) {
-    this.stream = stream;
-    this.options = options;
-  }
-
-  start() {
-    this.state = "recording";
-  }
-
-  stop() {
-    this.state = "inactive";
-    // Simulate async ondataavailable + onstop
-    if (this.ondataavailable) {
-      this.ondataavailable({ data: new Blob(["audio-data"], { type: "audio/webm" }) });
-    }
-    if (this.onstop) {
-      this.onstop();
-    }
-  }
-
-  pause() {
-    this.state = "paused";
-  }
-
-  resume() {
-    this.state = "recording";
-  }
-
-  static isTypeSupported(type: string): boolean {
-    return type === "audio/webm;codecs=opus";
-  }
-}
-
-// Mock MediaStream
-class MockMediaStream {
-  getTracks() {
-    return [{ stop: vi.fn() }];
-  }
-}
+import { MockMediaRecorder, MockMediaStream } from "../__mocks__/MockMediaRecorder";
 
 beforeEach(() => {
   vi.useFakeTimers();


### PR DESCRIPTION
## Summary
- `MockMediaRecorder` / `MockMediaStream` が `NewConsultationModal.test.tsx` と `useAudioRecorder.test.ts` に重複定義されていたのを `frontend/src/__mocks__/MockMediaRecorder.ts` に統一
- 動作の乖離（片方は `stop()` でコールバック発火、もう片方はしない）を解消し、正規版（behavioral mock）に一本化
- `/simplify` 3エージェントレビューで全員がHIGHと指摘した問題の修正

## Test plan
- [x] FE: 116テスト全パス
- [x] BE: 150テスト全パス
- [x] TypeScriptビルド通過
- [x] ESLint通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)