### PR TITLE
feat: ALLOWED_EMAILS環境変数で個別メール許可を追加

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -72,6 +72,6 @@ jobs:
             --memory=512Mi \
             --min-instances=0 \
             --max-instances=3 \
-            --set-env-vars="GCP_PROJECT_ID=${{ env.PROJECT_ID }},GCP_REGION=${{ env.REGION }}" \
+            --set-env-vars="^::^GCP_PROJECT_ID=${{ env.PROJECT_ID }}::GCP_REGION=${{ env.REGION }}::ALLOWED_EMAIL_DOMAINS=osaka-fujinhome.or.jp::ALLOWED_EMAILS=hy.unimail.11@gmail.com" \
             --service-account=kyugo-ai-deployer@kyugo-ai-dev.iam.gserviceaccount.com \
             --quiet

--- a/src/middleware/auth.test.ts
+++ b/src/middleware/auth.test.ts
@@ -547,6 +547,87 @@ describe("requireAuth middleware", () => {
     expect(res.json).toHaveBeenCalledWith({ error: "Internal server error" });
   });
 
+  it("allows individually listed email even when domain is not allowed", async () => {
+    const originalDomains = process.env.ALLOWED_EMAIL_DOMAINS;
+    const originalEmails = process.env.ALLOWED_EMAILS;
+    process.env.ALLOWED_EMAIL_DOMAINS = "osaka-fujinhome.or.jp";
+    process.env.ALLOWED_EMAILS = "hy.unimail.11@gmail.com";
+
+    vi.resetModules();
+    vi.mock("../config.js", () => ({
+      firebaseAuth: { verifyIdToken: vi.fn(), getUser: vi.fn() },
+      firestore: { collection: vi.fn() },
+    }));
+    const { requireAuth: freshRequireAuth } = await import("./auth.js");
+    const { firebaseAuth: freshFirebaseAuth, firestore: freshFirestore } = await import("../config.js");
+
+    vi.mocked(freshFirebaseAuth.verifyIdToken).mockResolvedValue({
+      uid: "gmail-uid",
+      email: "hy.unimail.11@gmail.com",
+      email_verified: true,
+    } as never);
+    vi.mocked(freshFirebaseAuth.getUser).mockResolvedValue({ disabled: false } as never);
+
+    const mockCreate = vi.fn().mockResolvedValue(undefined);
+    const mockDocGet = vi.fn().mockResolvedValue({ exists: false });
+    const mockDoc = vi.fn().mockReturnValue({ id: "gmail-uid", get: mockDocGet, create: mockCreate });
+    const mockQueryGet = vi.fn().mockResolvedValue({ empty: true, size: 0, docs: [] });
+    const mockWhere = vi.fn().mockReturnValue({ get: mockQueryGet });
+    vi.mocked(freshFirestore.collection).mockReturnValue({
+      where: mockWhere,
+      doc: mockDoc,
+    } as never);
+
+    const { req, res, next } = mockReqResNext("Bearer gmail-token");
+
+    await freshRequireAuth(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(mockCreate).toHaveBeenCalled();
+
+    process.env.ALLOWED_EMAIL_DOMAINS = originalDomains;
+    process.env.ALLOWED_EMAILS = originalEmails;
+  });
+
+  it("rejects email not in ALLOWED_EMAILS and not matching ALLOWED_EMAIL_DOMAINS", async () => {
+    const originalDomains = process.env.ALLOWED_EMAIL_DOMAINS;
+    const originalEmails = process.env.ALLOWED_EMAILS;
+    process.env.ALLOWED_EMAIL_DOMAINS = "osaka-fujinhome.or.jp";
+    process.env.ALLOWED_EMAILS = "hy.unimail.11@gmail.com";
+
+    vi.resetModules();
+    vi.mock("../config.js", () => ({
+      firebaseAuth: { verifyIdToken: vi.fn(), getUser: vi.fn() },
+      firestore: { collection: vi.fn() },
+    }));
+    const { requireAuth: freshRequireAuth } = await import("./auth.js");
+    const { firebaseAuth: freshFirebaseAuth, firestore: freshFirestore } = await import("../config.js");
+
+    vi.mocked(freshFirebaseAuth.verifyIdToken).mockResolvedValue({
+      uid: "random-uid",
+      email: "random@gmail.com",
+      email_verified: true,
+    } as never);
+    vi.mocked(freshFirebaseAuth.getUser).mockResolvedValue({ disabled: false } as never);
+
+    const mockDocGet = vi.fn().mockResolvedValue({ exists: false });
+    const mockDoc = vi.fn().mockReturnValue({ get: mockDocGet });
+    const mockQueryGet = vi.fn().mockResolvedValue({ empty: true, size: 0, docs: [] });
+    const mockWhere = vi.fn().mockReturnValue({ get: mockQueryGet });
+    vi.mocked(freshFirestore.collection).mockReturnValue({ doc: mockDoc, where: mockWhere } as never);
+
+    const { req, res, next } = mockReqResNext("Bearer random-token");
+
+    await freshRequireAuth(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({ error: "Access denied: email domain not allowed" });
+
+    process.env.ALLOWED_EMAIL_DOMAINS = originalDomains;
+    process.env.ALLOWED_EMAILS = originalEmails;
+  });
+
   it("uses doc(uid) as primary lookup for staff", async () => {
     vi.mocked(firebaseAuth.verifyIdToken).mockResolvedValue({
       uid: "direct-uid",

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -7,13 +7,20 @@ const parsedDomains = process.env.ALLOWED_EMAIL_DOMAINS
   : null;
 const allowedDomains = parsedDomains && parsedDomains.length > 0 ? parsedDomains : null;
 
-if (!allowedDomains) {
-  console.warn("WARNING: ALLOWED_EMAIL_DOMAINS is not set. Any authenticated user can auto-provision as staff.");
+const parsedEmails = process.env.ALLOWED_EMAILS
+  ? process.env.ALLOWED_EMAILS.split(",").map((e) => e.trim().toLowerCase()).filter((e) => e.length > 0)
+  : null;
+const allowedEmails = parsedEmails && parsedEmails.length > 0 ? parsedEmails : null;
+
+if (!allowedDomains && !allowedEmails) {
+  console.warn("WARNING: ALLOWED_EMAIL_DOMAINS and ALLOWED_EMAILS are not set. Any authenticated user can auto-provision as staff.");
 }
 
 function isEmailAllowed(email: string): boolean {
-  if (!allowedDomains) return true;
-  const domain = email.split("@")[1]?.toLowerCase();
+  const lowerEmail = email.toLowerCase();
+  if (allowedEmails && allowedEmails.includes(lowerEmail)) return true;
+  if (!allowedDomains) return !allowedEmails;
+  const domain = lowerEmail.split("@")[1];
   return !!domain && allowedDomains.includes(domain);
 }
 


### PR DESCRIPTION
## Summary
- `ALLOWED_EMAILS`環境変数を追加し、ドメイン制限(`ALLOWED_EMAIL_DOMAINS`)に加えて個別メールアドレスの許可をサポート
- CD環境変数に`osaka-fujinhome.or.jp`ドメインと開発者メール(`hy.unimail.11@gmail.com`)を設定
- `--set-env-vars`のセパレータを`^::^`に変更し、将来のカンマ含む値に対応

## 動作仕様
| メール | 判定 |
|--------|------|
| `*@osaka-fujinhome.or.jp` | ドメイン一致 → 許可 |
| `hy.unimail.11@gmail.com` | 個別メール一致 → 許可 |
| その他 | 403拒否 |

## Test plan
- [x] BE: 152テスト全パス（+2件追加）
- [x] FE: 116テスト全パス
- [x] TypeScriptビルド通過
- [x] ESLint通過
- [ ] CI通過確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Authentication now supports individual email allowlisting alongside domain-based access controls. Administrators can grant access to specific users by email address while maintaining broader domain-level restrictions, enabling more granular access management. Both methods can be used together for flexible, multi-level access control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->