### PR TITLE
feat: 管理者によるアカウント管理機能（ロール変更・無効化）

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -75,6 +75,15 @@ export interface UserInfo {
   staffId: string;
 }
 
+export interface StaffDetail {
+  id: string;
+  name: string;
+  email: string;
+  role: "admin" | "staff";
+  disabled: boolean;
+  createdAt: { _seconds: number } | null;
+}
+
 /** StaffSummary[] → { [id]: name } マップに変換 */
 export function buildStaffMap(staff: StaffSummary[]): Record<string, string> {
   const map: Record<string, string> = {};
@@ -129,6 +138,15 @@ export const api = {
   updateAllowedEmails: (data: { emails: string[]; domains: string[] }) =>
     request<{ emails: string[]; domains: string[] }>("/api/admin-settings/allowed-emails", {
       method: "PUT",
+      body: JSON.stringify(data),
+    }),
+
+  listAdminStaff: () =>
+    request<StaffDetail[]>("/api/admin-settings/staff"),
+
+  updateStaff: (id: string, data: { role?: "admin" | "staff"; disabled?: boolean }) =>
+    request<StaffDetail>(`/api/admin-settings/staff/${id}`, {
+      method: "PATCH",
       body: JSON.stringify(data),
     }),
 };

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2216,3 +2216,147 @@ a:hover { color: var(--ai-600); }
   padding: var(--space-3) var(--space-7);
   font-size: var(--text-base);
 }
+
+/* ── Settings Tabs ── */
+.settings-tabs {
+  display: flex;
+  gap: var(--space-1);
+  margin-bottom: var(--space-5);
+  border-bottom: 2px solid var(--ai-100);
+}
+
+.settings-tab {
+  padding: var(--space-2) var(--space-5);
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -2px;
+  font-size: var(--text-sm);
+  font-family: var(--font-body);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: color 0.2s, border-color 0.2s;
+}
+
+.settings-tab:hover {
+  color: var(--ai-600);
+}
+
+.settings-tab.active {
+  color: var(--ai-700);
+  border-bottom-color: var(--ai-600);
+  font-weight: 700;
+}
+
+/* ── Staff Table ── */
+.staff-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: var(--space-4);
+  font-size: var(--text-sm);
+}
+
+.staff-table th {
+  text-align: left;
+  padding: var(--space-2) var(--space-3);
+  border-bottom: 2px solid var(--ai-100);
+  color: var(--text-secondary);
+  font-weight: 600;
+  font-size: var(--text-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.staff-table td {
+  padding: var(--space-2) var(--space-3);
+  border-bottom: 1px solid var(--ai-50);
+  vertical-align: middle;
+}
+
+.staff-table tbody tr:hover {
+  background: var(--ai-50);
+}
+
+.staff-row-disabled {
+  opacity: 0.55;
+}
+
+.staff-role-select {
+  padding: var(--space-1) var(--space-2);
+  border: 1px solid var(--ai-100);
+  border-radius: var(--radius-sm);
+  background: var(--surface);
+  font-size: var(--text-xs);
+  font-family: var(--font-body);
+  color: var(--text-primary);
+  cursor: pointer;
+}
+
+.staff-role-select:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.badge-self {
+  display: inline-block;
+  margin-left: var(--space-2);
+  padding: 1px 6px;
+  font-size: 10px;
+  background: var(--ai-100);
+  color: var(--ai-700);
+  border-radius: var(--radius-sm);
+  font-weight: 600;
+}
+
+.badge-status {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: var(--radius-sm);
+  font-size: var(--text-xs);
+  font-weight: 600;
+}
+
+.badge-active {
+  background: #e8f5e9;
+  color: #2e7d32;
+}
+
+.badge-disabled {
+  background: #fce4ec;
+  color: #c62828;
+}
+
+.btn-sm {
+  padding: var(--space-1) var(--space-3);
+  font-size: var(--text-xs);
+  border-radius: var(--radius-sm);
+  border: 1px solid;
+  cursor: pointer;
+  font-family: var(--font-body);
+  transition: background 0.2s;
+}
+
+.btn-disable {
+  background: var(--surface);
+  border-color: #ef9a9a;
+  color: #c62828;
+}
+
+.btn-disable:hover:not(:disabled) {
+  background: #fce4ec;
+}
+
+.btn-enable {
+  background: var(--surface);
+  border-color: #a5d6a7;
+  color: #2e7d32;
+}
+
+.btn-enable:hover:not(:disabled) {
+  background: #e8f5e9;
+}
+
+.btn-sm:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}

--- a/frontend/src/pages/Settings.test.tsx
+++ b/frontend/src/pages/Settings.test.tsx
@@ -10,6 +10,8 @@ import { api } from "../api";
 beforeEach(() => {
   vi.mocked(api.getAllowedEmails).mockReset();
   vi.mocked(api.updateAllowedEmails).mockReset();
+  vi.mocked(api.listAdminStaff).mockReset();
+  vi.mocked(api.updateStaff).mockReset();
 });
 
 function renderSettings() {
@@ -22,7 +24,11 @@ function renderSettings() {
   );
 }
 
-describe("Settings", () => {
+describe("Settings - Whitelist tab", () => {
+  beforeEach(() => {
+    vi.mocked(api.getAllowedEmails).mockResolvedValue({ emails: [], domains: [] });
+  });
+
   it("shows loading state initially", () => {
     vi.mocked(api.getAllowedEmails).mockReturnValue(new Promise(() => {}));
     renderSettings();
@@ -31,7 +37,6 @@ describe("Settings", () => {
   });
 
   it("shows empty state when no config exists", async () => {
-    vi.mocked(api.getAllowedEmails).mockResolvedValue({ emails: [], domains: [] });
     renderSettings();
 
     await waitFor(() => {
@@ -54,7 +59,6 @@ describe("Settings", () => {
   });
 
   it("adds a new email", async () => {
-    vi.mocked(api.getAllowedEmails).mockResolvedValue({ emails: [], domains: [] });
     renderSettings();
 
     await waitFor(() => {
@@ -70,7 +74,6 @@ describe("Settings", () => {
   });
 
   it("adds a new domain", async () => {
-    vi.mocked(api.getAllowedEmails).mockResolvedValue({ emails: [], domains: [] });
     renderSettings();
 
     await waitFor(() => {
@@ -120,7 +123,6 @@ describe("Settings", () => {
   });
 
   it("saves changes and shows success message", async () => {
-    vi.mocked(api.getAllowedEmails).mockResolvedValue({ emails: [], domains: [] });
     vi.mocked(api.updateAllowedEmails).mockResolvedValue({
       emails: ["saved@test.com"],
       domains: [],
@@ -156,7 +158,6 @@ describe("Settings", () => {
   });
 
   it("shows error when saving fails", async () => {
-    vi.mocked(api.getAllowedEmails).mockResolvedValue({ emails: [], domains: [] });
     vi.mocked(api.updateAllowedEmails).mockRejectedValue(new Error("Save failed"));
     renderSettings();
 
@@ -208,5 +209,164 @@ describe("Settings", () => {
     await user.click(screen.getAllByText("追加")[1]);
 
     expect(screen.getByText("このドメインは既に登録されています")).toBeInTheDocument();
+  });
+});
+
+describe("Settings - Account management tab", () => {
+  const mockStaffList = [
+    { id: "test-staff-001", name: "テスト管理者", email: "test@example.com", role: "admin" as const, disabled: false, createdAt: null },
+    { id: "staff-2", name: "職員A", email: "a@test.com", role: "staff" as const, disabled: false, createdAt: null },
+    { id: "staff-3", name: "無効職員", email: "disabled@test.com", role: "staff" as const, disabled: true, createdAt: null },
+  ];
+
+  beforeEach(() => {
+    vi.mocked(api.getAllowedEmails).mockResolvedValue({ emails: [], domains: [] });
+    vi.mocked(api.listAdminStaff).mockResolvedValue(mockStaffList);
+  });
+
+  it("shows tab navigation", async () => {
+    renderSettings();
+    await waitFor(() => {
+      expect(screen.getByText("ログイン許可")).toBeInTheDocument();
+    });
+    expect(screen.getByText("アカウント管理")).toBeInTheDocument();
+  });
+
+  it("switches to account management tab and shows staff list", async () => {
+    renderSettings();
+    const user = userEvent.setup();
+
+    await waitFor(() => {
+      expect(screen.getByText("アカウント管理")).toBeInTheDocument();
+    });
+    await user.click(screen.getByText("アカウント管理"));
+
+    await waitFor(() => {
+      expect(screen.getByText("職員A")).toBeInTheDocument();
+    });
+    expect(screen.getByText("a@test.com")).toBeInTheDocument();
+    expect(screen.getByText("無効職員")).toBeInTheDocument();
+  });
+
+  it("shows self badge for current user", async () => {
+    renderSettings();
+    const user = userEvent.setup();
+
+    await waitFor(() => {
+      expect(screen.getByText("アカウント管理")).toBeInTheDocument();
+    });
+    await user.click(screen.getByText("アカウント管理"));
+
+    await waitFor(() => {
+      expect(screen.getByText("自分")).toBeInTheDocument();
+    });
+  });
+
+  it("disables role select and disable button for self", async () => {
+    renderSettings();
+    const user = userEvent.setup();
+
+    await waitFor(() => {
+      expect(screen.getByText("アカウント管理")).toBeInTheDocument();
+    });
+    await user.click(screen.getByText("アカウント管理"));
+
+    await waitFor(() => {
+      expect(screen.getByText("テスト管理者")).toBeInTheDocument();
+    });
+
+    // Find the row with self badge - the select and button should be disabled
+    const selects = screen.getAllByRole("combobox");
+    // First select (self) should be disabled
+    expect(selects[0]).toBeDisabled();
+  });
+
+  it("changes role via select", async () => {
+    vi.mocked(api.updateStaff).mockResolvedValue({
+      ...mockStaffList[1],
+      role: "admin",
+    });
+    renderSettings();
+    const user = userEvent.setup();
+
+    await waitFor(() => {
+      expect(screen.getByText("アカウント管理")).toBeInTheDocument();
+    });
+    await user.click(screen.getByText("アカウント管理"));
+
+    await waitFor(() => {
+      expect(screen.getByText("職員A")).toBeInTheDocument();
+    });
+
+    const selects = screen.getAllByRole("combobox");
+    // Second select is for staff-2
+    await user.selectOptions(selects[1], "admin");
+
+    await waitFor(() => {
+      expect(api.updateStaff).toHaveBeenCalledWith("staff-2", { role: "admin" });
+    });
+  });
+
+  it("toggles disabled status", async () => {
+    vi.mocked(api.updateStaff).mockResolvedValue({
+      ...mockStaffList[1],
+      disabled: true,
+    });
+    renderSettings();
+    const user = userEvent.setup();
+
+    await waitFor(() => {
+      expect(screen.getByText("アカウント管理")).toBeInTheDocument();
+    });
+    await user.click(screen.getByText("アカウント管理"));
+
+    await waitFor(() => {
+      expect(screen.getByText("職員A")).toBeInTheDocument();
+    });
+
+    // Find enabled "無効化" buttons (self button is disabled)
+    const disableButtons = screen.getAllByText("無効化").filter((btn) => !(btn as HTMLButtonElement).disabled);
+    await user.click(disableButtons[0]);
+
+    await waitFor(() => {
+      expect(api.updateStaff).toHaveBeenCalledWith("staff-2", { disabled: true });
+    });
+  });
+
+  it("shows error from API", async () => {
+    vi.mocked(api.listAdminStaff).mockRejectedValue(new Error("Failed to load staff"));
+    renderSettings();
+    const user = userEvent.setup();
+
+    await waitFor(() => {
+      expect(screen.getByText("アカウント管理")).toBeInTheDocument();
+    });
+    await user.click(screen.getByText("アカウント管理"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Failed to load staff")).toBeInTheDocument();
+    });
+  });
+
+  it("shows update error", async () => {
+    vi.mocked(api.updateStaff).mockRejectedValue(new Error("Cannot demote the last admin"));
+    renderSettings();
+    const user = userEvent.setup();
+
+    await waitFor(() => {
+      expect(screen.getByText("アカウント管理")).toBeInTheDocument();
+    });
+    await user.click(screen.getByText("アカウント管理"));
+
+    await waitFor(() => {
+      expect(screen.getByText("職員A")).toBeInTheDocument();
+    });
+
+    const disableButtons = screen.getAllByText("無効化").filter((btn) => !(btn as HTMLButtonElement).disabled);
+    await user.click(disableButtons[0]);
+
+    await waitFor(() => {
+      expect(screen.getByText("Cannot demote the last admin")).toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1,7 +1,53 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { api } from "../api";
+import type { StaffDetail } from "../api";
+import { useAuth } from "../contexts/AuthContext";
+
+function useSuccessMessage(durationMs = 3000) {
+  const [message, setMessage] = useState<string | null>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => () => { if (timerRef.current) clearTimeout(timerRef.current); }, []);
+  const show = useCallback((msg: string) => {
+    setMessage(msg);
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => setMessage(null), durationMs);
+  }, [durationMs]);
+  return { message, show };
+}
+
+type SettingsTab = "whitelist" | "accounts";
 
 export function Settings() {
+  const [activeTab, setActiveTab] = useState<SettingsTab>("whitelist");
+
+  return (
+    <>
+      <div className="page-header">
+        <h1>アクセス設定</h1>
+        <p className="page-header-subtitle">ログイン許可リストとアカウントの管理</p>
+      </div>
+      <div className="page-body">
+        <div className="settings-tabs">
+          <button
+            className={`settings-tab ${activeTab === "whitelist" ? "active" : ""}`}
+            onClick={() => setActiveTab("whitelist")}
+          >
+            ログイン許可
+          </button>
+          <button
+            className={`settings-tab ${activeTab === "accounts" ? "active" : ""}`}
+            onClick={() => setActiveTab("accounts")}
+          >
+            アカウント管理
+          </button>
+        </div>
+        {activeTab === "whitelist" ? <WhitelistSettings /> : <AccountSettings />}
+      </div>
+    </>
+  );
+}
+
+function WhitelistSettings() {
   const [emails, setEmails] = useState<string[]>([]);
   const [domains, setDomains] = useState<string[]>([]);
   const [newEmail, setNewEmail] = useState("");
@@ -9,12 +55,7 @@ export function Settings() {
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [successMessage, setSuccessMessage] = useState<string | null>(null);
-  const successTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  useEffect(() => () => {
-    if (successTimerRef.current) clearTimeout(successTimerRef.current);
-  }, []);
+  const { message: successMessage, show: showSuccess } = useSuccessMessage();
 
   const loadConfig = useCallback(async () => {
     setLoading(true);
@@ -35,14 +76,11 @@ export function Settings() {
   const handleSave = async () => {
     setSaving(true);
     setError(null);
-    setSuccessMessage(null);
     try {
       const result = await api.updateAllowedEmails({ emails, domains });
       setEmails(result.emails);
       setDomains(result.domains);
-      setSuccessMessage("保存しました");
-      if (successTimerRef.current) clearTimeout(successTimerRef.current);
-      successTimerRef.current = setTimeout(() => setSuccessMessage(null), 3000);
+      showSuccess("保存しました");
     } catch (err) {
       setError((err as Error).message);
     } finally {
@@ -93,96 +131,227 @@ export function Settings() {
 
   return (
     <>
-      <div className="page-header">
-        <h1>アクセス設定</h1>
-        <p className="page-header-subtitle">ログイン許可リストの管理</p>
-      </div>
-      <div className="page-body">
-        {error && <div className="alert-error">{error}</div>}
-        {successMessage && <div className="alert-success">{successMessage}</div>}
+      {error && <div className="alert-error">{error}</div>}
+      {successMessage && <div className="alert-success">{successMessage}</div>}
 
-        <div className="settings-layout">
-          {/* Allowed Emails */}
-          <div className="card settings-card">
-            <div className="card-body">
-              <h4 className="settings-card-title">
-                <span className="settings-icon">✉</span>
-                許可メールアドレス
-              </h4>
-              <p className="settings-card-desc">
-                個別のメールアドレスを指定してログインを許可します
-              </p>
-              <div className="settings-input-row">
-                <input
-                  type="email"
-                  className="settings-input"
-                  placeholder="user@example.com"
-                  value={newEmail}
-                  onChange={(e) => setNewEmail(e.target.value)}
-                  onKeyDown={(e) => { if (e.key === "Enter") addEmail(); }}
-                />
-                <button className="btn btn-primary settings-add-btn" onClick={addEmail}>追加</button>
-              </div>
-              <div className="settings-tag-list">
-                {emails.length === 0 ? (
-                  <p className="settings-empty">登録されたメールアドレスはありません</p>
-                ) : (
-                  emails.map((email) => (
-                    <span key={email} className="settings-tag settings-tag-email">
-                      {email}
-                      <button className="settings-tag-remove" onClick={() => removeEmail(email)} aria-label={`${email}を削除`}>×</button>
-                    </span>
-                  ))
-                )}
-              </div>
+      <div className="settings-layout">
+        <div className="card settings-card">
+          <div className="card-body">
+            <h4 className="settings-card-title">
+              <span className="settings-icon">✉</span>
+              許可メールアドレス
+            </h4>
+            <p className="settings-card-desc">
+              個別のメールアドレスを指定してログインを許可します
+            </p>
+            <div className="settings-input-row">
+              <input
+                type="email"
+                className="settings-input"
+                placeholder="user@example.com"
+                value={newEmail}
+                onChange={(e) => setNewEmail(e.target.value)}
+                onKeyDown={(e) => { if (e.key === "Enter") addEmail(); }}
+              />
+              <button className="btn btn-primary settings-add-btn" onClick={addEmail}>追加</button>
             </div>
-          </div>
-
-          {/* Allowed Domains */}
-          <div className="card settings-card">
-            <div className="card-body">
-              <h4 className="settings-card-title">
-                <span className="settings-icon">🌐</span>
-                許可ドメイン
-              </h4>
-              <p className="settings-card-desc">
-                指定ドメインのメールアドレスを持つユーザー全員にログインを許可します
-              </p>
-              <div className="settings-input-row">
-                <input
-                  type="text"
-                  className="settings-input"
-                  placeholder="example.com"
-                  value={newDomain}
-                  onChange={(e) => setNewDomain(e.target.value)}
-                  onKeyDown={(e) => { if (e.key === "Enter") addDomain(); }}
-                />
-                <button className="btn btn-primary settings-add-btn" onClick={addDomain}>追加</button>
-              </div>
-              <div className="settings-tag-list">
-                {domains.length === 0 ? (
-                  <p className="settings-empty">登録されたドメインはありません</p>
-                ) : (
-                  domains.map((domain) => (
-                    <span key={domain} className="settings-tag settings-tag-domain">
-                      @{domain}
-                      <button className="settings-tag-remove" onClick={() => removeDomain(domain)} aria-label={`${domain}を削除`}>×</button>
-                    </span>
-                  ))
-                )}
-              </div>
+            <div className="settings-tag-list">
+              {emails.length === 0 ? (
+                <p className="settings-empty">登録されたメールアドレスはありません</p>
+              ) : (
+                emails.map((email) => (
+                  <span key={email} className="settings-tag settings-tag-email">
+                    {email}
+                    <button className="settings-tag-remove" onClick={() => removeEmail(email)} aria-label={`${email}を削除`}>×</button>
+                  </span>
+                ))
+              )}
             </div>
           </div>
         </div>
 
-        <div className="settings-save-bar">
-          <button
-            className="btn btn-accent settings-save-btn"
-            onClick={handleSave}
-            disabled={saving}
-          >
-            {saving ? "保存中..." : "変更を保存"}
-          </button>
+        <div className="card settings-card">
+          <div className="card-body">
+            <h4 className="settings-card-title">
+              <span className="settings-icon">🌐</span>
+              許可ドメイン
+            </h4>
+            <p className="settings-card-desc">
+              指定ドメインのメールアドレスを持つユーザー全員にログインを許可します
+            </p>
+            <div className="settings-input-row">
+              <input
+                type="text"
+                className="settings-input"
+                placeholder="example.com"
+                value={newDomain}
+                onChange={(e) => setNewDomain(e.target.value)}
+                onKeyDown={(e) => { if (e.key === "Enter") addDomain(); }}
+              />
+              <button className="btn btn-primary settings-add-btn" onClick={addDomain}>追加</button>
+            </div>
+            <div className="settings-tag-list">
+              {domains.length === 0 ? (
+                <p className="settings-empty">登録されたドメインはありません</p>
+              ) : (
+                domains.map((domain) => (
+                  <span key={domain} className="settings-tag settings-tag-domain">
+                    @{domain}
+                    <button className="settings-tag-remove" onClick={() => removeDomain(domain)} aria-label={`${domain}を削除`}>×</button>
+                  </span>
+                ))
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="settings-save-bar">
+        <button
+          className="btn btn-accent settings-save-btn"
+          onClick={handleSave}
+          disabled={saving}
+        >
+          {saving ? "保存中..." : "変更を保存"}
+        </button>
+      </div>
+    </>
+  );
+}
+
+const ROLE_LABELS: Record<string, string> = { admin: "管理者", staff: "職員" };
+
+function AccountSettings() {
+  const { userInfo } = useAuth();
+  const [staffList, setStaffList] = useState<StaffDetail[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const { message: successMessage, show: showSuccess } = useSuccessMessage();
+  const [updating, setUpdating] = useState<string | null>(null);
+
+  const loadStaff = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await api.listAdminStaff();
+      setStaffList(data);
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { loadStaff(); }, [loadStaff]);
+
+  const handleRoleChange = async (staff: StaffDetail, newRole: "admin" | "staff") => {
+    if (staff.role === newRole) return;
+    setUpdating(staff.id);
+    setError(null);
+    try {
+      const updated = await api.updateStaff(staff.id, { role: newRole });
+      setStaffList((prev) => prev.map((s) => (s.id === staff.id ? updated : s)));
+      showSuccess(`${staff.name || staff.email} のロールを${ROLE_LABELS[newRole]}に変更しました`);
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setUpdating(null);
+    }
+  };
+
+  const handleToggleDisabled = async (staff: StaffDetail) => {
+    setUpdating(staff.id);
+    setError(null);
+    try {
+      const updated = await api.updateStaff(staff.id, { disabled: !staff.disabled });
+      setStaffList((prev) => prev.map((s) => (s.id === staff.id ? updated : s)));
+      showSuccess(`${staff.name || staff.email} を${updated.disabled ? "無効化" : "有効化"}しました`);
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setUpdating(null);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="loading-overlay">
+        <div className="spinner" />
+        <span>読み込み中...</span>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      {error && <div className="alert-error">{error}</div>}
+      {successMessage && <div className="alert-success">{successMessage}</div>}
+
+      <div className="card">
+        <div className="card-body">
+          <h4 className="settings-card-title">
+            <span className="settings-icon">👥</span>
+            アカウント一覧
+          </h4>
+          <p className="settings-card-desc">
+            登録済み職員のロール変更・アカウント無効化を管理します
+          </p>
+
+          {staffList.length === 0 ? (
+            <p className="settings-empty">登録された職員はいません</p>
+          ) : (
+            <table className="staff-table">
+              <thead>
+                <tr>
+                  <th>名前</th>
+                  <th>メールアドレス</th>
+                  <th>ロール</th>
+                  <th>状態</th>
+                  <th>操作</th>
+                </tr>
+              </thead>
+              <tbody>
+                {staffList.map((staff) => {
+                  const isSelf = staff.id === userInfo?.staffId;
+                  const isUpdating = updating === staff.id;
+                  return (
+                    <tr key={staff.id} className={staff.disabled ? "staff-row-disabled" : ""}>
+                      <td>
+                        {staff.name || "—"}
+                        {isSelf && <span className="badge-self">自分</span>}
+                      </td>
+                      <td>{staff.email || "—"}</td>
+                      <td>
+                        <select
+                          className="staff-role-select"
+                          value={staff.role}
+                          onChange={(e) => handleRoleChange(staff, e.target.value as "admin" | "staff")}
+                          disabled={isSelf || isUpdating}
+                        >
+                          <option value="admin">管理者</option>
+                          <option value="staff">職員</option>
+                        </select>
+                      </td>
+                      <td>
+                        <span className={`badge-status ${staff.disabled ? "badge-disabled" : "badge-active"}`}>
+                          {staff.disabled ? "無効" : "有効"}
+                        </span>
+                      </td>
+                      <td>
+                        <button
+                          className={`btn btn-sm ${staff.disabled ? "btn-enable" : "btn-disable"}`}
+                          onClick={() => handleToggleDisabled(staff)}
+                          disabled={isSelf || isUpdating}
+                        >
+                          {isUpdating ? "..." : staff.disabled ? "有効化" : "無効化"}
+                        </button>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          )}
         </div>
       </div>
     </>

--- a/frontend/src/test-setup.ts
+++ b/frontend/src/test-setup.ts
@@ -25,6 +25,8 @@ vi.mock("./api", async (importOriginal) => {
       listSupportMenus: vi.fn().mockResolvedValue([]),
       getAllowedEmails: vi.fn().mockResolvedValue({ emails: [], domains: [] }),
       updateAllowedEmails: vi.fn().mockResolvedValue({ emails: [], domains: [] }),
+      listAdminStaff: vi.fn().mockResolvedValue([]),
+      updateStaff: vi.fn(),
     },
   };
 });

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -102,6 +102,10 @@ export async function requireAuth(req: Request, res: Response, next: NextFunctio
 
     if (primaryDoc.exists) {
       const data = primaryDoc.data()!;
+      if (data.disabled) {
+        res.status(403).json({ error: "Your account has been disabled" });
+        return;
+      }
       staffId = primaryDoc.id;
       role = (data.role as "admin" | "staff") ?? "staff";
       staffName = (data.name as string) ?? "";
@@ -125,6 +129,10 @@ export async function requireAuth(req: Request, res: Response, next: NextFunctio
       if (legacyQuery.size === 1) {
         // レガシーレコード発見
         const staffDoc = legacyQuery.docs[0];
+        if (staffDoc.data().disabled) {
+          res.status(403).json({ error: "Your account has been disabled" });
+          return;
+        }
         staffId = staffDoc.id;
         role = (staffDoc.data().role as "admin" | "staff") ?? "staff";
         staffName = (staffDoc.data().name as string) ?? "";
@@ -165,6 +173,10 @@ export async function requireAuth(req: Request, res: Response, next: NextFunctio
             const existingData = existingDoc.data();
             if (!existingData) {
               throw new Error("Staff document exists but has no data");
+            }
+            if (existingData.disabled) {
+              res.status(403).json({ error: "Your account has been disabled" });
+              return;
             }
             staffId = existingDoc.id;
             role = (existingData.role as "admin" | "staff") ?? "staff";

--- a/src/routes/admin-settings.ts
+++ b/src/routes/admin-settings.ts
@@ -6,6 +6,110 @@ export const adminSettingsRouter = Router();
 
 adminSettingsRouter.use(requireAdmin);
 
+function toStaffResponse(doc: FirebaseFirestore.DocumentSnapshot) {
+  const data = doc.data()!;
+  return {
+    id: doc.id,
+    name: (data.name as string) ?? "",
+    email: (data.email as string) ?? "",
+    role: (data.role as string) ?? "staff",
+    disabled: (data.disabled as boolean) ?? false,
+    createdAt: data.createdAt ?? null,
+  };
+}
+
+// GET /api/admin-settings/staff - 職員一覧（管理用：全フィールド）
+adminSettingsRouter.get("/staff", async (_req: Request, res: Response) => {
+  try {
+    const snapshot = await firestore.collection("staff").get();
+    const staff = snapshot.docs.map(toStaffResponse);
+    res.json(staff);
+  } catch (err) {
+    console.error("Admin staff list failed", (err as Error).message);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+// PATCH /api/admin-settings/staff/:id - 職員のロール変更・無効化
+adminSettingsRouter.patch("/staff/:id", async (req: Request, res: Response) => {
+  const id = req.params.id as string;
+  const { role, disabled } = req.body;
+
+  // 入力検証
+  if (role !== undefined && role !== "admin" && role !== "staff") {
+    res.status(400).json({ error: "role must be 'admin' or 'staff'" });
+    return;
+  }
+  if (disabled !== undefined && typeof disabled !== "boolean") {
+    res.status(400).json({ error: "disabled must be a boolean" });
+    return;
+  }
+  if (role === undefined && disabled === undefined) {
+    res.status(400).json({ error: "At least one of role or disabled is required" });
+    return;
+  }
+
+  try {
+    const staffRef = firestore.collection("staff").doc(id);
+    const staffDoc = await staffRef.get();
+    if (!staffDoc.exists) {
+      res.status(404).json({ error: "Staff not found" });
+      return;
+    }
+
+    // admin自身のロール降格防止
+    if (role === "staff" && id === req.user!.staffId) {
+      res.status(400).json({ error: "Cannot demote yourself" });
+      return;
+    }
+
+    // admin自身の無効化防止
+    if (disabled === true && id === req.user!.staffId) {
+      res.status(400).json({ error: "Cannot disable yourself" });
+      return;
+    }
+
+    // 最後のadmin降格防止
+    if (role === "staff") {
+      const currentData = staffDoc.data()!;
+      if (currentData.role === "admin") {
+        const adminSnapshot = await firestore.collection("staff")
+          .where("role", "==", "admin")
+          .where("disabled", "==", false)
+          .limit(2)
+          .get();
+        const activeAdmins = adminSnapshot.docs.filter(
+          (d) => d.id !== id,
+        );
+        if (activeAdmins.length === 0) {
+          res.status(400).json({ error: "Cannot demote the last admin" });
+          return;
+        }
+      }
+    }
+
+    const updateData: Record<string, unknown> = { updatedAt: new Date() };
+    if (role !== undefined) updateData.role = role;
+    if (disabled !== undefined) updateData.disabled = disabled;
+
+    await staffRef.update(updateData);
+
+    const existingData = staffDoc.data()!;
+    const merged = { ...existingData, ...updateData };
+    res.json({
+      id,
+      name: (merged.name as string) ?? "",
+      email: (merged.email as string) ?? "",
+      role: (merged.role as string) ?? "staff",
+      disabled: (merged.disabled as boolean) ?? false,
+      createdAt: merged.createdAt ?? null,
+    });
+  } catch (err) {
+    console.error("Staff update failed", (err as Error).message);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
 // GET /api/admin-settings/allowed-emails
 adminSettingsRouter.get("/allowed-emails", async (_req: Request, res: Response) => {
   try {

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -1234,3 +1234,168 @@ describe("PUT /api/admin-settings/allowed-emails", () => {
     expect(res.body.error).toBe("Internal server error");
   });
 });
+
+// ============================================================
+// GET /api/admin-settings/staff
+// ============================================================
+describe("GET /api/admin-settings/staff", () => {
+  it("returns 403 for non-admin", async () => {
+    const res = await request(app).get("/api/admin-settings/staff");
+    expect(res.status).toBe(403);
+  });
+
+  it("returns staff list with all fields for admin", async () => {
+    const mockDocs = [
+      { id: "s1", data: () => ({ name: "職員A", email: "a@test.com", role: "staff", disabled: false, createdAt: new Date() }) },
+      { id: "s2", data: () => ({ name: "管理者B", email: "b@test.com", role: "admin", disabled: true, createdAt: new Date() }) },
+    ];
+    const mockGet = vi.fn().mockResolvedValue({ docs: mockDocs });
+    vi.mocked(firestore.collection).mockReturnValue({ get: mockGet } as never);
+
+    const res = await request(adminApp).get("/api/admin-settings/staff");
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(2);
+    expect(res.body[0]).toEqual(expect.objectContaining({ id: "s1", name: "職員A", email: "a@test.com", role: "staff", disabled: false }));
+    expect(res.body[1]).toEqual(expect.objectContaining({ id: "s2", name: "管理者B", email: "b@test.com", role: "admin", disabled: true }));
+  });
+
+  it("returns 500 when Firestore fails", async () => {
+    const mockGet = vi.fn().mockRejectedValue(new Error("Firestore error"));
+    vi.mocked(firestore.collection).mockReturnValue({ get: mockGet } as never);
+
+    const res = await request(adminApp).get("/api/admin-settings/staff");
+    expect(res.status).toBe(500);
+  });
+});
+
+// ============================================================
+// PATCH /api/admin-settings/staff/:id
+// ============================================================
+describe("PATCH /api/admin-settings/staff/:id", () => {
+  const mockUpdate = vi.fn().mockResolvedValue(undefined);
+
+  beforeEach(() => {
+    mockUpdate.mockClear();
+  });
+
+  it("returns 403 for non-admin", async () => {
+    const res = await request(app).patch("/api/admin-settings/staff/s1").send({ role: "admin" });
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 400 for invalid role", async () => {
+    const res = await request(adminApp).patch("/api/admin-settings/staff/s1").send({ role: "superadmin" });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("role must be 'admin' or 'staff'");
+  });
+
+  it("returns 400 for invalid disabled", async () => {
+    const res = await request(adminApp).patch("/api/admin-settings/staff/s1").send({ disabled: "yes" });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("disabled must be a boolean");
+  });
+
+  it("returns 400 when no fields provided", async () => {
+    const res = await request(adminApp).patch("/api/admin-settings/staff/s1").send({});
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("At least one of role or disabled is required");
+  });
+
+  it("returns 404 for nonexistent staff", async () => {
+    vi.mocked(firestore.collection).mockReturnValue({
+      doc: vi.fn().mockReturnValue({
+        get: vi.fn().mockResolvedValue({ exists: false }),
+        update: mockUpdate,
+      }),
+    } as never);
+
+    const res = await request(adminApp).patch("/api/admin-settings/staff/nonexistent").send({ role: "admin" });
+    expect(res.status).toBe(404);
+  });
+
+  it("prevents admin from demoting themselves", async () => {
+    const staffData = { name: "管理者", role: "admin" };
+    vi.mocked(firestore.collection).mockReturnValue({
+      doc: vi.fn().mockReturnValue({
+        get: vi.fn().mockResolvedValue({ exists: true, id: "admin-staff", data: () => staffData }),
+        update: mockUpdate,
+      }),
+    } as never);
+
+    const res = await request(adminApp).patch("/api/admin-settings/staff/admin-staff").send({ role: "staff" });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("Cannot demote yourself");
+  });
+
+  it("prevents admin from disabling themselves", async () => {
+    const staffData = { name: "管理者", role: "admin" };
+    vi.mocked(firestore.collection).mockReturnValue({
+      doc: vi.fn().mockReturnValue({
+        get: vi.fn().mockResolvedValue({ exists: true, id: "admin-staff", data: () => staffData }),
+        update: mockUpdate,
+      }),
+    } as never);
+
+    const res = await request(adminApp).patch("/api/admin-settings/staff/admin-staff").send({ disabled: true });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("Cannot disable yourself");
+  });
+
+  it("prevents demoting the last admin", async () => {
+    const staffData = { name: "唯一の管理者", role: "admin", email: "other@test.com" };
+    const adminQueryDocs = [{ id: "other-admin", data: () => ({ role: "admin", disabled: false }) }];
+
+    const mockWhereChain = {
+      where: vi.fn().mockReturnValue({
+        limit: vi.fn().mockReturnValue({
+          get: vi.fn().mockResolvedValue({ docs: adminQueryDocs }),
+        }),
+      }),
+    };
+    vi.mocked(firestore.collection).mockReturnValue({
+      doc: vi.fn().mockReturnValue({
+        get: vi.fn().mockResolvedValue({ exists: true, id: "other-admin", data: () => staffData }),
+        update: mockUpdate,
+      }),
+      where: vi.fn().mockReturnValue(mockWhereChain),
+    } as never);
+
+    const res = await request(adminApp).patch("/api/admin-settings/staff/other-admin").send({ role: "staff" });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("Cannot demote the last admin");
+  });
+
+  it("successfully updates role", async () => {
+    const staffData = { name: "職員A", email: "a@test.com", role: "staff", disabled: false, createdAt: new Date() };
+    const updatedData = { ...staffData, role: "admin" };
+    const mockGet = vi.fn()
+      .mockResolvedValueOnce({ exists: true, id: "s1", data: () => staffData })
+      .mockResolvedValueOnce({ exists: true, id: "s1", data: () => updatedData });
+    const mockRef = { get: mockGet, update: mockUpdate };
+    vi.mocked(firestore.collection).mockReturnValue({
+      doc: vi.fn().mockReturnValue(mockRef),
+    } as never);
+
+    const res = await request(adminApp).patch("/api/admin-settings/staff/s1").send({ role: "admin" });
+    expect(res.status).toBe(200);
+    expect(res.body.role).toBe("admin");
+    expect(mockUpdate).toHaveBeenCalledWith(expect.objectContaining({ role: "admin" }));
+  });
+
+  it("successfully toggles disabled", async () => {
+    const staffData = { name: "職員A", email: "a@test.com", role: "staff", disabled: false, createdAt: new Date() };
+    const updatedData = { ...staffData, disabled: true };
+    const mockGet = vi.fn()
+      .mockResolvedValueOnce({ exists: true, id: "s1", data: () => staffData })
+      .mockResolvedValueOnce({ exists: true, id: "s1", data: () => updatedData });
+    const mockRef = { get: mockGet, update: mockUpdate };
+    vi.mocked(firestore.collection).mockReturnValue({
+      doc: vi.fn().mockReturnValue(mockRef),
+    } as never);
+
+    const res = await request(adminApp).patch("/api/admin-settings/staff/s1").send({ disabled: true });
+    expect(res.status).toBe(200);
+    expect(res.body.disabled).toBe(true);
+    expect(mockUpdate).toHaveBeenCalledWith(expect.objectContaining({ disabled: true }));
+  });
+});


### PR DESCRIPTION
## Summary
- **アカウント管理タブ**: 設定画面にタブUI追加、管理者が職員のロール変更・アカウント無効化を管理
- **BE API**: `GET/PATCH /api/admin-settings/staff` エンドポイント新設（自己降格・最後のadmin降格防止ガード付き）
- **セキュリティ強化**: requireAuth内のALREADY_EXISTS分岐にdisabledチェック追加
- **品質改善**: `/simplify` 3エージェントレビュー + `/safe-refactor` 実施。toStaffResponseヘルパー抽出、useSuccessMessageフック抽出、PATCH後のFirestore再読み取り除去、adminチェックlimit(2)最適化

Closes #97

## 変更内容
| ファイル | 変更 |
|---------|------|
| `src/routes/admin-settings.ts` | GET/PATCH staffエンドポイント、toStaffResponseヘルパー |
| `src/middleware/auth.ts` | ALREADY_EXISTS分岐のdisabledチェック追加 |
| `src/server.test.ts` | admin staff APIテスト13件追加 |
| `frontend/src/api.ts` | StaffDetail型、listAdminStaff/updateStaff API |
| `frontend/src/pages/Settings.tsx` | タブUI、AccountSettings、useSuccessMessageフック |
| `frontend/src/pages/Settings.test.tsx` | アカウント管理テスト8件追加 |
| `frontend/src/index.css` | タブ・テーブル・バッジスタイル |
| `frontend/src/test-setup.ts` | listAdminStaff/updateStaffモック追加 |

## Quality Gate
- /simplify: 3エージェント並列レビュー実施（DRY違反修正、効率最適化、セキュリティ修正）
- /safe-refactor: HIGH 1件 + MEDIUM 2件修正、LOW 3件スキップ
- TypeScript: 通過
- テスト: 317件全パス（BE: 178, FE: 139）
- Lint: 通過
- Build: 通過

## Test plan
- [x] BE: admin staff GET/PATCHテスト13件（正常/異常/ガード）
- [x] FE: アカウント管理テスト8件（タブ/リスト/ロール変更/無効化/エラー）
- [x] 全テスト317件パス
- [ ] ブラウザでの動作確認（設定画面→アカウント管理タブ→ロール変更・無効化操作）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added account management tab in Settings page for administrative staff control.
  * Enabled viewing and managing staff members: change roles, toggle account enabled/disabled status.
  * Implemented automatic success messaging for staff updates.
  * Added account disablement checks at authentication layer to prevent disabled account access.

* **Tests**
  * Comprehensive test coverage for staff management endpoints and UI workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->