### PR TITLE
fix: staff auto-provisionでdisabled: falseを明示的に設定

### DIFF
--- a/src/middleware/auth.test.ts
+++ b/src/middleware/auth.test.ts
@@ -271,7 +271,9 @@ describe("requireAuth middleware", () => {
     await freshRequireAuth(req, res, next);
 
     expect(next).toHaveBeenCalled();
-    expect(mockCreate).toHaveBeenCalled();
+    expect(mockCreate).toHaveBeenCalledWith(expect.objectContaining({
+      disabled: false,
+    }));
     expect(req.user).toEqual({
       uid: "allowed-uid",
       email: "user@allowed.gov.jp",
@@ -342,6 +344,7 @@ describe("requireAuth middleware", () => {
       firebaseUid: "new-uid",
       email: "new@example.com",
       role: "staff",
+      disabled: false,
     }));
     expect(req.user).toEqual({
       uid: "new-uid",

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -160,6 +160,7 @@ export async function requireAuth(req: Request, res: Response, next: NextFunctio
             email: decoded.email ?? "",
             name: decoded.name ?? "",
             role: "staff",
+            disabled: false,
             createdAt: new Date(),
           });
           staffId = newStaffRef.id;

--- a/src/types.ts
+++ b/src/types.ts
@@ -84,6 +84,7 @@ export interface Staff {
   name: string;
   email: string;
   role: "admin" | "staff";
+  disabled: boolean;
   officeId: string;
   createdAt: Timestamp;
 }


### PR DESCRIPTION
## Summary
- staff自動プロビジョニング時に`disabled: false`を明示的に設定
- `where("disabled", "==", false)`クエリが未設定ドキュメントを返さない問題を修正
- Staff型にdisabledフィールドを追加

Closes #99

## 変更内容
| ファイル | 変更 |
|---------|------|
| `src/middleware/auth.ts` | auto-provision時に`disabled: false`追加 |
| `src/types.ts` | Staff interfaceに`disabled: boolean`追加 |
| `src/middleware/auth.test.ts` | disabledフィールド検証を2テストに追加 |

## Test plan
- [x] BE: 178件全パス
- [x] FE: 139件全パス（計317件）
- [x] TypeScriptビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Staff accounts are now initialized with an enabled status during auto-provisioning.

* **Tests**
  * Updated tests to verify account initialization behavior during auto-provisioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->