### PR TITLE
feat: 個別支援計画書のAI下書き生成（救護施設標準様式対応）

### DIFF
--- a/firestore/firestore.rules
+++ b/firestore/firestore.rules
@@ -22,6 +22,17 @@ service cloud.firestore {
       // delete禁止（論理削除のみ）
       allow delete: if false;
 
+      // 個別支援計画書（サブコレクション）: 親ケースの担当職員 or admin
+      match /supportPlans/{planId} {
+        allow read: if request.auth != null
+          && (isAdmin() || get(/databases/$(database)/documents/cases/$(caseId)).data.assignedStaffId == request.auth.uid);
+        allow create: if request.auth != null
+          && (isAdmin() || get(/databases/$(database)/documents/cases/$(caseId)).data.assignedStaffId == request.auth.uid);
+        allow update: if request.auth != null
+          && (isAdmin() || get(/databases/$(database)/documents/cases/$(caseId)).data.assignedStaffId == request.auth.uid);
+        allow delete: if false;
+      }
+
       // 相談記録（サブコレクション）: 親ケースの担当職員 or admin
       match /consultations/{consultationId} {
         allow read: if request.auth != null

--- a/firestore/firestore.rules.test.ts
+++ b/firestore/firestore.rules.test.ts
@@ -164,6 +164,88 @@ describe("cases", () => {
 });
 
 // ============================================================
+// supportPlans サブコレクション
+// ============================================================
+describe("supportPlans", () => {
+  async function setupSupportPlanData(caseId: string, planId: string, assignedStaffId: string) {
+    await setupCaseData(caseId, assignedStaffId);
+    await testEnv.withSecurityRulesDisabled(async (context) => {
+      const db = context.firestore();
+      await setDoc(doc(db, "cases", caseId, "supportPlans", planId), {
+        staffId: assignedStaffId,
+        status: "draft",
+        clientName: "テスト太郎",
+        overallPolicy: "支援方針",
+        goals: [],
+        specialNotes: "",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+    });
+  }
+
+  it("未認証ユーザーは支援計画書を読み取れない", async () => {
+    await setupSupportPlanData("case-1", "plan-1", STAFF_UID);
+    const db = unauthContext().firestore();
+    await assertFails(getDoc(doc(db, "cases", "case-1", "supportPlans", "plan-1")));
+  });
+
+  it("親ケース担当者は支援計画書を読み取れる", async () => {
+    await setupSupportPlanData("case-1", "plan-1", STAFF_UID);
+    const db = staffContext(STAFF_UID).firestore();
+    await assertSucceeds(getDoc(doc(db, "cases", "case-1", "supportPlans", "plan-1")));
+  });
+
+  it("非担当者は支援計画書を読み取れない", async () => {
+    await setupSupportPlanData("case-1", "plan-1", STAFF_UID);
+    const db = staffContext(OTHER_STAFF_UID).firestore();
+    await assertFails(getDoc(doc(db, "cases", "case-1", "supportPlans", "plan-1")));
+  });
+
+  it("親ケース担当者は支援計画書を作成できる", async () => {
+    await setupCaseData("case-1", STAFF_UID);
+    const db = staffContext(STAFF_UID).firestore();
+    await assertSucceeds(addDoc(collection(db, "cases", "case-1", "supportPlans"), {
+      staffId: STAFF_UID,
+      status: "draft",
+      clientName: "テスト太郎",
+      overallPolicy: "支援方針",
+      goals: [],
+      specialNotes: "",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    }));
+  });
+
+  it("非担当者は支援計画書を作成できない", async () => {
+    await setupCaseData("case-1", STAFF_UID);
+    const db = staffContext(OTHER_STAFF_UID).firestore();
+    await assertFails(addDoc(collection(db, "cases", "case-1", "supportPlans"), {
+      staffId: OTHER_STAFF_UID,
+      status: "draft",
+      clientName: "テスト太郎",
+      overallPolicy: "支援方針",
+      goals: [],
+      specialNotes: "",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    }));
+  });
+
+  it("adminは支援計画書を更新できる", async () => {
+    await setupSupportPlanData("case-1", "plan-1", STAFF_UID);
+    const db = adminContext().firestore();
+    await assertSucceeds(updateDoc(doc(db, "cases", "case-1", "supportPlans", "plan-1"), { status: "confirmed" }));
+  });
+
+  it("支援計画書の削除は禁止", async () => {
+    await setupSupportPlanData("case-1", "plan-1", STAFF_UID);
+    const db = staffContext(STAFF_UID).firestore();
+    await assertFails(deleteDoc(doc(db, "cases", "case-1", "supportPlans", "plan-1")));
+  });
+});
+
+// ============================================================
 // consultations サブコレクション
 // ============================================================
 describe("consultations", () => {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -84,6 +84,32 @@ export interface StaffDetail {
   createdAt: { _seconds: number } | null;
 }
 
+export interface SupportPlanGoal {
+  area: string;
+  longTermGoal: string;
+  shortTermGoal: string;
+  supports: string[];
+  frequency: string;
+  responsible: string;
+}
+
+export interface SupportPlan {
+  id: string;
+  caseId: string;
+  staffId: string;
+  status: "draft" | "confirmed";
+  clientName: string;
+  clientId: string;
+  overallPolicy: string;
+  goals: SupportPlanGoal[];
+  specialNotes: string;
+  planStartDate: string;
+  nextReviewDate: string;
+  confirmedAt?: { _seconds: number };
+  createdAt: { _seconds: number };
+  updatedAt: { _seconds: number };
+}
+
 /** StaffSummary[] → { [id]: name } マップに変換 */
 export function buildStaffMap(staff: StaffSummary[]): Record<string, string> {
   const map: Record<string, string> = {};
@@ -146,6 +172,19 @@ export const api = {
 
   updateStaff: (id: string, data: { role?: "admin" | "staff"; disabled?: boolean }) =>
     request<StaffDetail>(`/api/admin-settings/staff/${id}`, {
+      method: "PATCH",
+      body: JSON.stringify(data),
+    }),
+
+  // 支援計画書
+  generateSupportPlanDraft: (caseId: string) =>
+    request<SupportPlan>(`/api/cases/${caseId}/support-plan/draft`, { method: "POST" }),
+
+  getSupportPlan: (caseId: string) =>
+    request<SupportPlan>(`/api/cases/${caseId}/support-plan`),
+
+  updateSupportPlan: (caseId: string, planId: string, data: Partial<SupportPlan>) =>
+    request<SupportPlan>(`/api/cases/${caseId}/support-plan/${planId}`, {
       method: "PATCH",
       body: JSON.stringify(data),
     }),

--- a/frontend/src/components/SupportPlanView.tsx
+++ b/frontend/src/components/SupportPlanView.tsx
@@ -1,0 +1,243 @@
+import { useState } from "react";
+import { api } from "../api";
+import type { SupportPlan, SupportPlanGoal } from "../api";
+import { formatDateTime } from "../constants";
+
+interface SupportPlanViewProps {
+  caseId: string;
+  plan: SupportPlan | null;
+  onUpdate: () => void;
+}
+
+type EditData = {
+  overallPolicy: string;
+  goals: SupportPlanGoal[];
+  specialNotes: string;
+  planStartDate: string;
+  nextReviewDate: string;
+};
+
+export function SupportPlanView({ caseId, plan, onUpdate }: SupportPlanViewProps) {
+  const [generating, setGenerating] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [editData, setEditData] = useState<EditData | null>(null);
+
+  const editing = editData !== null;
+
+  const updateGoal = (index: number, patch: Partial<SupportPlanGoal>) => {
+    if (!editData) return;
+    const goals = [...editData.goals];
+    goals[index] = { ...goals[index], ...patch };
+    setEditData({ ...editData, goals });
+  };
+
+  const handleGenerate = async () => {
+    setGenerating(true);
+    setError(null);
+    try {
+      await api.generateSupportPlanDraft(caseId);
+      onUpdate();
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setGenerating(false);
+    }
+  };
+
+  const startEditing = () => {
+    if (!plan) return;
+    setEditData({
+      overallPolicy: plan.overallPolicy,
+      goals: plan.goals.map((g) => ({ ...g, supports: [...g.supports] })),
+      specialNotes: plan.specialNotes,
+      planStartDate: plan.planStartDate,
+      nextReviewDate: plan.nextReviewDate,
+    });
+  };
+
+  const handleSave = async () => {
+    if (!plan || !editData) return;
+    setSaving(true);
+    setError(null);
+    try {
+      await api.updateSupportPlan(caseId, plan.id, editData);
+      setEditData(null);
+      onUpdate();
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleConfirm = async () => {
+    if (!plan) return;
+    if (!confirm("この支援計画書を確定しますか？確定後は編集できなくなります。")) return;
+    setSaving(true);
+    setError(null);
+    try {
+      await api.updateSupportPlan(caseId, plan.id, { status: "confirmed" });
+      onUpdate();
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (!plan) {
+    return (
+      <div className="support-plan-empty">
+        <div className="empty-state">
+          <div className="empty-state-icon">📋</div>
+          <p className="empty-state-text">支援計画書がありません</p>
+          <p className="empty-state-subtext">
+            相談記録のAI分析結果をもとに、個別支援計画書の下書きを自動生成します。
+          </p>
+          <button
+            className="btn btn-accent"
+            onClick={handleGenerate}
+            disabled={generating}
+          >
+            {generating ? "生成中..." : "AI下書きを生成"}
+          </button>
+          {error && <p className="support-plan-error">{error}</p>}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="support-plan">
+      <div className="support-plan-header">
+        <div>
+          <h3>個別支援計画書</h3>
+          <span className={`badge badge-plan-${plan.status}`}>
+            {plan.status === "draft" ? "下書き" : "確定"}
+          </span>
+        </div>
+        <div className="support-plan-actions">
+          {plan.status === "draft" && !editing && (
+            <>
+              <button className="btn btn-secondary" onClick={handleGenerate} disabled={generating}>
+                {generating ? "再生成中..." : "再生成"}
+              </button>
+              <button className="btn btn-primary" onClick={startEditing}>
+                編集
+              </button>
+              <button className="btn btn-accent" onClick={handleConfirm} disabled={saving}>
+                確定
+              </button>
+            </>
+          )}
+          {editing && (
+            <>
+              <button className="btn btn-ghost" onClick={() => setEditData(null)}>
+                キャンセル
+              </button>
+              <button className="btn btn-primary" onClick={handleSave} disabled={saving}>
+                {saving ? "保存中..." : "保存"}
+              </button>
+            </>
+          )}
+        </div>
+      </div>
+
+      {error && <p className="support-plan-error">{error}</p>}
+
+      <div className="support-plan-meta">
+        <span>作成日: {formatDateTime(plan.createdAt)}</span>
+        <span>計画期間: {plan.planStartDate} 〜 {plan.nextReviewDate}</span>
+        {plan.confirmedAt && <span>確定日: {formatDateTime(plan.confirmedAt)}</span>}
+      </div>
+
+      <div className="support-plan-section">
+        <h4>全体的な支援方針</h4>
+        {editData ? (
+          <textarea
+            className="support-plan-textarea"
+            value={editData.overallPolicy}
+            onChange={(e) => setEditData({ ...editData, overallPolicy: e.target.value })}
+          />
+        ) : (
+          <p className="support-plan-text">{plan.overallPolicy}</p>
+        )}
+      </div>
+
+      <div className="support-plan-section">
+        <h4>支援目標・内容</h4>
+        {(editData ? editData.goals : plan.goals).map((goal, i) => (
+          <div key={i} className="support-plan-goal">
+            <div className="goal-area-badge">{goal.area}</div>
+            <div className="goal-grid">
+              <div>
+                <div className="goal-label">長期目標（6ヶ月〜1年）</div>
+                {editData ? (
+                  <textarea
+                    className="support-plan-input"
+                    value={editData.goals[i].longTermGoal}
+                    onChange={(e) => updateGoal(i, { longTermGoal: e.target.value })}
+                  />
+                ) : (
+                  <p>{goal.longTermGoal}</p>
+                )}
+              </div>
+              <div>
+                <div className="goal-label">短期目標（3ヶ月）</div>
+                {editData ? (
+                  <textarea
+                    className="support-plan-input"
+                    value={editData.goals[i].shortTermGoal}
+                    onChange={(e) => updateGoal(i, { shortTermGoal: e.target.value })}
+                  />
+                ) : (
+                  <p>{goal.shortTermGoal}</p>
+                )}
+              </div>
+            </div>
+            <div className="goal-supports">
+              <div className="goal-label">具体的な支援内容</div>
+              <ul>
+                {goal.supports.map((s, j) => (
+                  <li key={j}>
+                    {editData ? (
+                      <input
+                        className="support-plan-input-inline"
+                        value={editData.goals[i].supports[j]}
+                        onChange={(e) => {
+                          const supports = [...editData.goals[i].supports];
+                          supports[j] = e.target.value;
+                          updateGoal(i, { supports });
+                        }}
+                      />
+                    ) : (
+                      s
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </div>
+            <div className="goal-meta">
+              <span>頻度: {goal.frequency}</span>
+              <span>担当: {goal.responsible}</span>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div className="support-plan-section">
+        <h4>特記事項</h4>
+        {editData ? (
+          <textarea
+            className="support-plan-textarea"
+            value={editData.specialNotes}
+            onChange={(e) => setEditData({ ...editData, specialNotes: e.target.value })}
+          />
+        ) : (
+          <p className="support-plan-text">{plan.specialNotes || "（なし）"}</p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2217,15 +2217,19 @@ a:hover { color: var(--ai-600); }
   font-size: var(--text-base);
 }
 
-/* ── Settings Tabs ── */
-.settings-tabs {
+/* ── Common Tabs ── */
+.settings-tabs,
+.detail-tabs {
   display: flex;
   gap: var(--space-1);
-  margin-bottom: var(--space-5);
+  margin-bottom: var(--space-4);
   border-bottom: 2px solid var(--ai-100);
 }
 
-.settings-tab {
+.settings-tabs { margin-bottom: var(--space-5); }
+
+.settings-tab,
+.detail-tab {
   padding: var(--space-2) var(--space-5);
   background: none;
   border: none;
@@ -2238,11 +2242,13 @@ a:hover { color: var(--ai-600); }
   transition: color 0.2s, border-color 0.2s;
 }
 
-.settings-tab:hover {
+.settings-tab:hover,
+.detail-tab:hover {
   color: var(--ai-600);
 }
 
-.settings-tab.active {
+.settings-tab.active,
+.detail-tab.active {
   color: var(--ai-700);
   border-bottom-color: var(--ai-600);
   font-weight: 700;
@@ -2359,4 +2365,184 @@ a:hover { color: var(--ai-600); }
 .btn-sm:disabled {
   cursor: not-allowed;
   opacity: 0.5;
+}
+
+/* ── Support Plan ── */
+.support-plan {
+  padding: var(--space-3) 0;
+}
+
+.support-plan-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--space-4);
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.support-plan-header h3 {
+  display: inline;
+  margin-right: var(--space-2);
+}
+
+.support-plan-actions {
+  display: flex;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+}
+
+.badge-plan-draft {
+  background: var(--warning-bg, #fff3cd);
+  color: var(--warning-text, #856404);
+  padding: 2px 10px;
+  border-radius: 12px;
+  font-size: var(--text-xs);
+  font-weight: 600;
+}
+
+.badge-plan-confirmed {
+  background: var(--success-bg, #d4edda);
+  color: var(--success-text, #155724);
+  padding: 2px 10px;
+  border-radius: 12px;
+  font-size: var(--text-xs);
+  font-weight: 600;
+}
+
+.support-plan-meta {
+  display: flex;
+  gap: var(--space-4);
+  margin-bottom: var(--space-4);
+  font-size: var(--text-xs);
+  color: var(--text-secondary);
+  flex-wrap: wrap;
+}
+
+.support-plan-section {
+  margin-bottom: var(--space-5);
+}
+
+.support-plan-section h4 {
+  font-size: var(--text-sm);
+  font-weight: 700;
+  color: var(--ai-700);
+  margin-bottom: var(--space-2);
+  padding-bottom: var(--space-1);
+  border-bottom: 1px solid var(--ai-100);
+}
+
+.support-plan-text {
+  font-size: var(--text-sm);
+  line-height: 1.7;
+  color: var(--text-primary);
+  white-space: pre-wrap;
+}
+
+.support-plan-textarea {
+  width: 100%;
+  min-height: 80px;
+  padding: var(--space-2);
+  border: 1px solid var(--ai-200);
+  border-radius: 6px;
+  font-family: var(--font-body);
+  font-size: var(--text-sm);
+  line-height: 1.6;
+  resize: vertical;
+}
+
+.support-plan-input {
+  width: 100%;
+  min-height: 48px;
+  padding: var(--space-1) var(--space-2);
+  border: 1px solid var(--ai-200);
+  border-radius: 4px;
+  font-family: var(--font-body);
+  font-size: var(--text-sm);
+  resize: vertical;
+}
+
+.support-plan-input-inline {
+  width: 100%;
+  padding: 2px var(--space-1);
+  border: 1px solid var(--ai-200);
+  border-radius: 4px;
+  font-family: var(--font-body);
+  font-size: var(--text-sm);
+}
+
+.support-plan-error {
+  color: var(--status-closed);
+  font-size: var(--text-sm);
+  margin-top: var(--space-2);
+}
+
+/* Goal cards */
+.support-plan-goal {
+  background: var(--surface);
+  border: 1px solid var(--ai-100);
+  border-radius: 8px;
+  padding: var(--space-3);
+  margin-bottom: var(--space-3);
+}
+
+.goal-area-badge {
+  display: inline-block;
+  background: var(--ai-50);
+  color: var(--ai-700);
+  padding: 2px 12px;
+  border-radius: 12px;
+  font-size: var(--text-xs);
+  font-weight: 600;
+  margin-bottom: var(--space-2);
+}
+
+.goal-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-3);
+  margin-bottom: var(--space-2);
+}
+
+@media (max-width: 768px) {
+  .goal-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.goal-label {
+  font-size: var(--text-xs);
+  font-weight: 600;
+  color: var(--text-secondary);
+  margin-bottom: var(--space-1);
+}
+
+.goal-grid p {
+  font-size: var(--text-sm);
+  line-height: 1.6;
+  margin: 0;
+}
+
+.goal-supports {
+  margin-bottom: var(--space-2);
+}
+
+.goal-supports ul {
+  margin: var(--space-1) 0 0 var(--space-4);
+  padding: 0;
+}
+
+.goal-supports li {
+  font-size: var(--text-sm);
+  line-height: 1.7;
+  margin-bottom: 2px;
+}
+
+.goal-meta {
+  display: flex;
+  gap: var(--space-4);
+  font-size: var(--text-xs);
+  color: var(--text-secondary);
+  padding-top: var(--space-2);
+  border-top: 1px solid var(--ai-50);
 }

--- a/frontend/src/pages/CaseDetail.tsx
+++ b/frontend/src/pages/CaseDetail.tsx
@@ -1,10 +1,13 @@
 import { useState, useEffect, useCallback } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { api, buildStaffMap } from "../api";
-import type { Case, Consultation } from "../api";
+import type { Case, Consultation, SupportPlan } from "../api";
 import { NewConsultationModal } from "../components/NewConsultationModal";
 import { SuggestedSupports } from "../components/SuggestedSupports";
+import { SupportPlanView } from "../components/SupportPlanView";
 import { STATUS_LABELS, TYPE_LABELS, formatDate, formatDateTime } from "../constants";
+
+type DetailTab = "consultations" | "support-plan";
 
 export function CaseDetail() {
   const { id } = useParams<{ id: string }>();
@@ -15,20 +18,23 @@ export function CaseDetail() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [showNewConsultation, setShowNewConsultation] = useState(false);
+  const [activeTab, setActiveTab] = useState<DetailTab>("consultations");
+  const [supportPlan, setSupportPlan] = useState<SupportPlan | null>(null);
 
   const loadData = useCallback(async () => {
     if (!id) return;
     setLoading(true);
     setError(null);
     try {
-      const [c, cons] = await Promise.all([
+      const [c, cons, plan, staff] = await Promise.all([
         api.getCase(id),
         api.listConsultations(id),
+        api.getSupportPlan(id).catch(() => null),
+        api.listStaff().catch(() => [] as { id: string; name: string }[]),
       ]);
       setCaseData(c);
       setConsultations(cons);
-      // staffは補助情報。失敗しても主データの表示を妨げない
-      const staff = await api.listStaff().catch(() => [] as never);
+      setSupportPlan(plan);
       setStaffMap(buildStaffMap(staff));
     } catch (err) {
       console.error("Failed to load case:", err);
@@ -95,8 +101,29 @@ export function CaseDetail() {
 
       <div className="page-body">
         <div className="detail-layout">
-          {/* Main: Consultation Timeline (Golden Ratio: 61.8%) */}
+          {/* Main: Tabbed Content (Golden Ratio: 61.8%) */}
           <div>
+            <div className="detail-tabs">
+              <button
+                className={`detail-tab ${activeTab === "consultations" ? "active" : ""}`}
+                onClick={() => setActiveTab("consultations")}
+              >
+                相談記録 ({consultations.length})
+              </button>
+              <button
+                className={`detail-tab ${activeTab === "support-plan" ? "active" : ""}`}
+                onClick={() => setActiveTab("support-plan")}
+              >
+                支援計画書 {supportPlan ? (supportPlan.status === "confirmed" ? "✓" : "") : ""}
+              </button>
+            </div>
+
+            {activeTab === "support-plan" && (
+              <SupportPlanView caseId={id!} plan={supportPlan} onUpdate={loadData} />
+            )}
+
+            {activeTab === "consultations" && (
+            <>
             <div className="section-header">
               <h3>相談記録</h3>
               <button className="btn btn-accent" onClick={() => setShowNewConsultation(true)}>
@@ -186,6 +213,8 @@ export function CaseDetail() {
                   </div>
                 ))}
               </div>
+            )}
+            </>
             )}
           </div>
 

--- a/frontend/src/test-setup.ts
+++ b/frontend/src/test-setup.ts
@@ -27,6 +27,9 @@ vi.mock("./api", async (importOriginal) => {
       updateAllowedEmails: vi.fn().mockResolvedValue({ emails: [], domains: [] }),
       listAdminStaff: vi.fn().mockResolvedValue([]),
       updateStaff: vi.fn(),
+      generateSupportPlanDraft: vi.fn(),
+      getSupportPlan: vi.fn().mockRejectedValue(new Error("Not found")),
+      updateSupportPlan: vi.fn(),
     },
   };
 });

--- a/src/repositories/support-plan-repository.ts
+++ b/src/repositories/support-plan-repository.ts
@@ -1,0 +1,63 @@
+import { Timestamp } from "@google-cloud/firestore";
+import { firestore } from "../config.js";
+import { SupportPlan } from "../types.js";
+
+function supportPlansRef(caseId: string) {
+  return firestore.collection("cases").doc(caseId).collection("supportPlans");
+}
+
+export async function createSupportPlan(
+  caseId: string,
+  data: Omit<SupportPlan, "id" | "caseId" | "createdAt" | "updatedAt" | "confirmedAt">,
+): Promise<SupportPlan> {
+  const now = Timestamp.now();
+  const planData: Omit<SupportPlan, "id"> = {
+    ...data,
+    caseId,
+    createdAt: now,
+    updatedAt: now,
+  };
+  const docRef = await supportPlansRef(caseId).add(planData);
+  return { id: docRef.id, ...planData };
+}
+
+export async function getSupportPlan(caseId: string, planId: string): Promise<SupportPlan | null> {
+  const doc = await supportPlansRef(caseId).doc(planId).get();
+  if (!doc.exists) return null;
+  return { id: doc.id, caseId, ...doc.data() } as SupportPlan;
+}
+
+export async function listSupportPlans(caseId: string): Promise<SupportPlan[]> {
+  const snapshot = await supportPlansRef(caseId).orderBy("createdAt", "desc").get();
+  return snapshot.docs.map((doc) => ({ id: doc.id, caseId, ...doc.data() }) as SupportPlan);
+}
+
+export async function getLatestSupportPlan(caseId: string): Promise<SupportPlan | null> {
+  const snapshot = await supportPlansRef(caseId).orderBy("createdAt", "desc").limit(1).get();
+  if (snapshot.empty) return null;
+  const doc = snapshot.docs[0];
+  return { id: doc.id, caseId, ...doc.data() } as SupportPlan;
+}
+
+export async function updateSupportPlan(
+  caseId: string,
+  planId: string,
+  data: Partial<Pick<SupportPlan, "overallPolicy" | "goals" | "specialNotes" | "planStartDate" | "nextReviewDate" | "status">>,
+): Promise<SupportPlan> {
+  const current = await getSupportPlan(caseId, planId);
+  if (!current) throw new Error(`SupportPlan ${planId} not found`);
+  if (current.status === "confirmed") {
+    throw new Error("Cannot edit a confirmed support plan");
+  }
+
+  const now = Timestamp.now();
+  const update: Record<string, unknown> = { ...data, updatedAt: now };
+
+  // 確定時にconfirmedAtを設定
+  if (data.status === "confirmed") {
+    update.confirmedAt = now;
+  }
+
+  await supportPlansRef(caseId).doc(planId).update(update);
+  return { ...current, ...update, updatedAt: now } as SupportPlan;
+}

--- a/src/routes/cases.ts
+++ b/src/routes/cases.ts
@@ -8,6 +8,7 @@ import {
   updateCaseStatusSchema,
 } from "../schemas/case.js";
 import { consultationsRouter } from "./consultations.js";
+import { supportPlansRouter } from "./support-plans.js";
 
 function validate<T>(schema: ZodType<T>, data: unknown): { success: true; data: T } | { success: false; error: string } {
   const result = schema.safeParse(data);
@@ -23,6 +24,9 @@ export const casesRouter = Router();
 
 // 相談記録ルートを委譲
 casesRouter.use("/:id/consultations", consultationsRouter);
+
+// 支援計画書ルートを委譲
+casesRouter.use("/:id/support-plan", supportPlansRouter);
 
 // POST /api/cases - ケース作成（assignedStaffIdはreq.userから強制）
 casesRouter.post("/", async (req: Request, res: Response) => {

--- a/src/routes/support-plans.ts
+++ b/src/routes/support-plans.ts
@@ -1,0 +1,128 @@
+import { Router, Request, Response } from "express";
+import type { ZodType } from "zod";
+import * as supportPlanRepo from "../repositories/support-plan-repository.js";
+import * as consultationRepo from "../repositories/consultation-repository.js";
+import * as supportMenuRepo from "../repositories/support-menu-repository.js";
+import { generateSupportPlanDraft } from "../services/ai.js";
+import { requireCaseAccess } from "../middleware/authz.js";
+import { updateSupportPlanSchema } from "../schemas/case.js";
+import { Case } from "../types.js";
+
+function paramStr(value: string | string[]): string {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+function validate<T>(schema: ZodType<T>, data: unknown): { success: true; data: T } | { success: false; error: string } {
+  const result = schema.safeParse(data);
+  if (result.success) return { success: true, data: result.data };
+  return { success: false, error: result.error.issues.map((e) => e.message).join(", ") };
+}
+
+export const supportPlansRouter = Router({ mergeParams: true });
+
+// 全エンドポイントでケースアクセス権を確認
+supportPlansRouter.use(requireCaseAccess);
+
+// POST /api/cases/:id/support-plan/draft — AI下書き生成
+supportPlansRouter.post("/draft", async (req: Request, res: Response) => {
+  const caseId = paramStr(req.params.id);
+  const caseData = req.caseData as Case;
+
+  try {
+    // 相談記録と支援メニューを収集
+    const [consultations, menus] = await Promise.all([
+      consultationRepo.listConsultations(caseId),
+      supportMenuRepo.listSupportMenus(),
+    ]);
+
+    const completedConsultations = consultations.filter((c) => c.aiStatus === "completed");
+    if (completedConsultations.length === 0) {
+      res.status(400).json({ error: "AI分析が完了した相談記録がありません。先に相談記録を作成してください。" });
+      return;
+    }
+
+    // AI生成
+    const aiResult = await generateSupportPlanDraft(caseData, consultations, menus);
+
+    // 計画開始日: 今日、次回見直し日: 3ヶ月後
+    const today = new Date();
+    const reviewDate = new Date(today);
+    reviewDate.setMonth(reviewDate.getMonth() + 3);
+
+    const formatDate = (d: Date) =>
+      `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+
+    const plan = await supportPlanRepo.createSupportPlan(caseId, {
+      staffId: req.user!.staffId,
+      status: "draft",
+      clientName: caseData.clientName,
+      clientId: caseData.clientId,
+      overallPolicy: aiResult.overallPolicy,
+      goals: aiResult.goals,
+      specialNotes: aiResult.specialNotes,
+      planStartDate: formatDate(today),
+      nextReviewDate: formatDate(reviewDate),
+    });
+
+    res.status(201).json(plan);
+  } catch (err) {
+    console.error("Support plan draft generation failed", (err as Error).message);
+    res.status(500).json({ error: "支援計画書の生成に失敗しました" });
+  }
+});
+
+// GET /api/cases/:id/support-plan — 最新の計画書取得
+supportPlansRouter.get("/", async (req: Request, res: Response) => {
+  const caseId = paramStr(req.params.id);
+  try {
+    const plan = await supportPlanRepo.getLatestSupportPlan(caseId);
+    if (!plan) {
+      res.status(404).json({ error: "支援計画書が見つかりません" });
+      return;
+    }
+    res.json(plan);
+  } catch (err) {
+    console.error("Get support plan failed", (err as Error).message);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+// GET /api/cases/:id/support-plan/list — 全履歴取得
+supportPlansRouter.get("/list", async (req: Request, res: Response) => {
+  const caseId = paramStr(req.params.id);
+  try {
+    const plans = await supportPlanRepo.listSupportPlans(caseId);
+    res.json(plans);
+  } catch (err) {
+    console.error("List support plans failed", (err as Error).message);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+// PATCH /api/cases/:id/support-plan/:planId — 編集・確定
+supportPlansRouter.patch("/:planId", async (req: Request, res: Response) => {
+  const caseId = paramStr(req.params.id);
+  const planId = paramStr(req.params.planId);
+  const parsed = validate(updateSupportPlanSchema, req.body);
+  if (!parsed.success) {
+    res.status(400).json({ error: parsed.error });
+    return;
+  }
+
+  try {
+    const plan = await supportPlanRepo.updateSupportPlan(caseId, planId, parsed.data);
+    res.json(plan);
+  } catch (err) {
+    const message = (err as Error).message;
+    if (message.includes("not found")) {
+      res.status(404).json({ error: message });
+      return;
+    }
+    if (message.includes("Cannot edit")) {
+      res.status(400).json({ error: message });
+      return;
+    }
+    console.error("Update support plan failed", message);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});

--- a/src/schemas/case.ts
+++ b/src/schemas/case.ts
@@ -39,6 +39,25 @@ export const createAudioConsultationSchema = z.object({
   context: z.string().max(10000).optional().default(""),
 });
 
+// 個別支援計画書
+const supportPlanGoalSchema = z.object({
+  area: z.string().min(1).max(100),
+  longTermGoal: z.string().min(1).max(500),
+  shortTermGoal: z.string().min(1).max(500),
+  supports: z.array(z.string().min(1).max(500)).min(1).max(20),
+  frequency: z.string().min(1).max(100),
+  responsible: z.string().min(1).max(200),
+});
+
+export const updateSupportPlanSchema = z.object({
+  overallPolicy: z.string().min(1).max(2000).optional(),
+  goals: z.array(supportPlanGoalSchema).min(1).max(20).optional(),
+  specialNotes: z.string().max(5000).optional(),
+  planStartDate: dateString.optional(),
+  nextReviewDate: dateString.optional(),
+  status: z.enum(["draft", "confirmed"]).optional(),
+});
+
 // 管理者設定: ログイン許可リスト
 export const allowedEmailsSchema = z.object({
   emails: z.array(z.string().email({ error: "Invalid email address" }).max(254)).max(500),

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -44,9 +44,18 @@ vi.mock("./repositories/support-menu-repository.js", () => ({
   listSupportMenus: vi.fn(),
 }));
 
+vi.mock("./repositories/support-plan-repository.js", () => ({
+  createSupportPlan: vi.fn(),
+  getSupportPlan: vi.fn(),
+  getLatestSupportPlan: vi.fn(),
+  listSupportPlans: vi.fn(),
+  updateSupportPlan: vi.fn(),
+}));
+
 vi.mock("./services/ai.js", () => ({
   analyzeConsultation: vi.fn(),
   analyzeAudioConsultation: vi.fn(),
+  generateSupportPlanDraft: vi.fn(),
 }));
 
 vi.mock("./services/ai-retry.js", () => ({
@@ -63,7 +72,8 @@ import { retryPendingConsultations } from "./services/ai-retry.js";
 import * as caseRepo from "./repositories/case-repository.js";
 import * as consultationRepo from "./repositories/consultation-repository.js";
 import * as supportMenuRepo from "./repositories/support-menu-repository.js";
-import { analyzeConsultation, analyzeAudioConsultation } from "./services/ai.js";
+import { analyzeConsultation, analyzeAudioConsultation, generateSupportPlanDraft } from "./services/ai.js";
+import * as supportPlanRepo from "./repositories/support-plan-repository.js";
 import { Timestamp } from "@google-cloud/firestore";
 import { firebaseAuth, firestore } from "./config.js";
 
@@ -1411,5 +1421,186 @@ describe("PATCH /api/admin-settings/staff/:id", () => {
     expect(res.status).toBe(200);
     expect(res.body.disabled).toBe(true);
     expect(mockUpdate).toHaveBeenCalledWith(expect.objectContaining({ disabled: true }));
+  });
+});
+
+// ============================================================
+// Support Plan API
+// ============================================================
+
+const MOCK_CONSULTATION_COMPLETED = {
+  id: "cons-1",
+  caseId: "case-1",
+  staffId: "staff-1",
+  content: "生活困窮の相談",
+  transcript: "",
+  summary: "生活保護の相談。収入が低く生活が困難。",
+  suggestedSupports: [{ menuId: "m1", menuName: "生活保護", reason: "収入不足", relevanceScore: 0.9 }],
+  consultationType: "visit" as const,
+  aiStatus: "completed" as const,
+  createdAt: NOW,
+  updatedAt: NOW,
+};
+
+const MOCK_SUPPORT_PLAN = {
+  id: "plan-1",
+  caseId: "case-1",
+  staffId: "staff-1",
+  status: "draft" as const,
+  clientName: "テスト太郎",
+  clientId: "client-001",
+  overallPolicy: "生活保護受給に向けた支援",
+  goals: [{
+    area: "経済的自立",
+    longTermGoal: "安定した生活基盤の確立",
+    shortTermGoal: "生活保護の申請手続き完了",
+    supports: ["生活保護申請支援", "家計相談"],
+    frequency: "週1回",
+    responsible: "生活支援員",
+  }],
+  specialNotes: "持病あり",
+  planStartDate: "2026-03-10",
+  nextReviewDate: "2026-06-10",
+  createdAt: NOW,
+  updatedAt: NOW,
+};
+
+describe("Support Plan API", () => {
+  describe("POST /api/cases/:id/support-plan/draft", () => {
+    it("generates a support plan draft from consultations", async () => {
+      vi.mocked(caseRepo.getCase).mockResolvedValue(MOCK_CASE);
+      vi.mocked(consultationRepo.listConsultations).mockResolvedValue([MOCK_CONSULTATION_COMPLETED]);
+      vi.mocked(supportMenuRepo.listSupportMenus).mockResolvedValue([]);
+      vi.mocked(generateSupportPlanDraft).mockResolvedValue({
+        overallPolicy: "生活保護受給に向けた支援",
+        goals: MOCK_SUPPORT_PLAN.goals,
+        specialNotes: "持病あり",
+      });
+      vi.mocked(supportPlanRepo.createSupportPlan).mockResolvedValue(MOCK_SUPPORT_PLAN);
+
+      const res = await request(app).post("/api/cases/case-1/support-plan/draft");
+      expect(res.status).toBe(201);
+      expect(res.body.overallPolicy).toBe("生活保護受給に向けた支援");
+      expect(res.body.goals).toHaveLength(1);
+      expect(generateSupportPlanDraft).toHaveBeenCalledWith(
+        MOCK_CASE,
+        [MOCK_CONSULTATION_COMPLETED],
+        [],
+      );
+    });
+
+    it("returns 400 when no completed consultations exist", async () => {
+      vi.mocked(caseRepo.getCase).mockResolvedValue(MOCK_CASE);
+      vi.mocked(consultationRepo.listConsultations).mockResolvedValue([
+        { ...MOCK_CONSULTATION_COMPLETED, aiStatus: "pending" as const, summary: "" },
+      ]);
+      vi.mocked(supportMenuRepo.listSupportMenus).mockResolvedValue([]);
+
+      const res = await request(app).post("/api/cases/case-1/support-plan/draft");
+      expect(res.status).toBe(400);
+      expect(res.body.error).toContain("AI分析が完了した相談記録がありません");
+    });
+
+    it("returns 403 for unauthorized access", async () => {
+      vi.mocked(caseRepo.getCase).mockResolvedValue(OTHER_STAFF_CASE);
+
+      const res = await request(app).post("/api/cases/case-other/support-plan/draft");
+      expect(res.status).toBe(403);
+    });
+  });
+
+  describe("GET /api/cases/:id/support-plan", () => {
+    it("returns the latest support plan", async () => {
+      vi.mocked(caseRepo.getCase).mockResolvedValue(MOCK_CASE);
+      vi.mocked(supportPlanRepo.getLatestSupportPlan).mockResolvedValue(MOCK_SUPPORT_PLAN);
+
+      const res = await request(app).get("/api/cases/case-1/support-plan");
+      expect(res.status).toBe(200);
+      expect(res.body.id).toBe("plan-1");
+      expect(res.body.status).toBe("draft");
+    });
+
+    it("returns 404 when no support plan exists", async () => {
+      vi.mocked(caseRepo.getCase).mockResolvedValue(MOCK_CASE);
+      vi.mocked(supportPlanRepo.getLatestSupportPlan).mockResolvedValue(null);
+
+      const res = await request(app).get("/api/cases/case-1/support-plan");
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe("PATCH /api/cases/:id/support-plan/:planId", () => {
+    it("updates a draft support plan", async () => {
+      vi.mocked(caseRepo.getCase).mockResolvedValue(MOCK_CASE);
+      vi.mocked(supportPlanRepo.updateSupportPlan).mockResolvedValue({
+        ...MOCK_SUPPORT_PLAN,
+        overallPolicy: "更新された支援方針",
+      });
+
+      const res = await request(app)
+        .patch("/api/cases/case-1/support-plan/plan-1")
+        .send({ overallPolicy: "更新された支援方針" });
+      expect(res.status).toBe(200);
+      expect(res.body.overallPolicy).toBe("更新された支援方針");
+    });
+
+    it("confirms a support plan", async () => {
+      vi.mocked(caseRepo.getCase).mockResolvedValue(MOCK_CASE);
+      vi.mocked(supportPlanRepo.updateSupportPlan).mockResolvedValue({
+        ...MOCK_SUPPORT_PLAN,
+        status: "confirmed",
+        confirmedAt: NOW,
+      });
+
+      const res = await request(app)
+        .patch("/api/cases/case-1/support-plan/plan-1")
+        .send({ status: "confirmed" });
+      expect(res.status).toBe(200);
+      expect(res.body.status).toBe("confirmed");
+    });
+
+    it("returns 400 when editing a confirmed plan", async () => {
+      vi.mocked(caseRepo.getCase).mockResolvedValue(MOCK_CASE);
+      vi.mocked(supportPlanRepo.updateSupportPlan).mockRejectedValue(
+        new Error("Cannot edit a confirmed support plan"),
+      );
+
+      const res = await request(app)
+        .patch("/api/cases/case-1/support-plan/plan-1")
+        .send({ overallPolicy: "変更" });
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 404 for non-existent plan", async () => {
+      vi.mocked(caseRepo.getCase).mockResolvedValue(MOCK_CASE);
+      vi.mocked(supportPlanRepo.updateSupportPlan).mockRejectedValue(
+        new Error("SupportPlan nonexistent not found"),
+      );
+
+      const res = await request(app)
+        .patch("/api/cases/case-1/support-plan/nonexistent")
+        .send({ overallPolicy: "変更" });
+      expect(res.status).toBe(404);
+    });
+
+    it("returns 400 for invalid input", async () => {
+      vi.mocked(caseRepo.getCase).mockResolvedValue(MOCK_CASE);
+
+      const res = await request(app)
+        .patch("/api/cases/case-1/support-plan/plan-1")
+        .send({ status: "invalid_status" });
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe("GET /api/cases/:id/support-plan/list", () => {
+    it("returns all support plans for a case", async () => {
+      vi.mocked(caseRepo.getCase).mockResolvedValue(MOCK_CASE);
+      vi.mocked(supportPlanRepo.listSupportPlans).mockResolvedValue([MOCK_SUPPORT_PLAN]);
+
+      const res = await request(app).get("/api/cases/case-1/support-plan/list");
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveLength(1);
+    });
   });
 });

--- a/src/services/ai.ts
+++ b/src/services/ai.ts
@@ -1,5 +1,5 @@
 import { generativeModel } from "../config.js";
-import { AISummaryResult, AudioAnalysisResult, Consultation, SupportMenu } from "../types.js";
+import { AISummaryResult, AISupportPlanResult, AudioAnalysisResult, Case, Consultation, SupportMenu } from "../types.js";
 
 const SYSTEM_INSTRUCTION_TEXT = `あなたは福祉相談支援AIアシスタントです。
 生活困窮者の相談内容を分析し、以下を行います：
@@ -141,4 +141,95 @@ ${buildMenuList(availableMenus)}
     }));
   }
   return parseAIResponse<AudioAnalysisResult>(responseText, ["transcript", "summary", "suggestedSupports"]);
+}
+
+// 個別支援計画書の下書き生成
+const SYSTEM_INSTRUCTION_SUPPORT_PLAN = `あなたは救護施設の個別支援計画策定を支援するAIアシスタントです。
+厚生労働省委託「救護施設・更生施設における個別支援計画 策定導入マニュアル」（令和6年3月、全社協発行）の標準様式に準拠した
+個別支援計画書の下書きを生成します。
+
+以下の原則に従ってください：
+- 利用者本人の希望・意向を最大限尊重した目標設定
+- ICF（国際生活機能分類）の視点で生活機能を多面的に評価
+- 長期目標は6ヶ月〜1年、短期目標は3ヶ月程度の期間設定
+- 具体的・測定可能な目標表現（「〜できるようになる」「〜の頻度を週X回にする」等）
+- 支援領域は日常生活・健康管理・社会参加・経済的自立等から該当するものを選択
+
+回答は必ず以下のJSON形式で返してください：
+{
+  "overallPolicy": "全体的な支援方針（利用者の状況と目指す方向性を200文字以内で）",
+  "goals": [
+    {
+      "area": "支援領域（例: 日常生活、健康管理、社会参加、経済的自立）",
+      "longTermGoal": "長期目標（6ヶ月〜1年）",
+      "shortTermGoal": "短期目標（3ヶ月）",
+      "supports": ["具体的な支援内容1", "具体的な支援内容2"],
+      "frequency": "支援頻度（例: 毎日、週3回、月1回）",
+      "responsible": "担当者・機関（例: 生活支援員、看護師、外部医療機関）"
+    }
+  ],
+  "specialNotes": "特記事項（アレルギー、服薬情報、家族関係等、支援上の留意点）"
+}`;
+
+export async function generateSupportPlanDraft(
+  caseData: Case,
+  consultations: Consultation[],
+  availableMenus: SupportMenu[],
+): Promise<AISupportPlanResult> {
+  // 相談記録の要約を時系列で構成
+  const consultationSummaries = consultations
+    .filter((c) => c.aiStatus === "completed" && c.summary)
+    .map((c) => {
+      const supports = c.suggestedSupports
+        .map((s) => `  - ${s.menuName}（${s.reason}、関連度: ${Math.round(s.relevanceScore * 100)}%）`)
+        .join("\n");
+      return `### ${c.consultationType} 相談（${c.createdAt}）
+内容: ${c.content}
+AI要約: ${c.summary}
+提案された支援メニュー:
+${supports || "  なし"}`;
+    })
+    .join("\n\n");
+
+  const userPrompt = `## 利用者情報
+- 氏名: ${caseData.clientName}
+- ID: ${caseData.clientId}
+- 生年月日: ${caseData.dateOfBirth}
+- ケース状態: ${caseData.status}
+
+## 世帯情報
+${JSON.stringify(caseData.householdInfo || {})}
+
+## 収入情報
+${JSON.stringify(caseData.incomeInfo || {})}
+
+## 相談記録（${consultations.length}件）
+${consultationSummaries || "（相談記録なし）"}
+
+## 利用可能な支援メニュー
+${buildMenuList(availableMenus)}
+
+上記の情報を基に、この利用者の個別支援計画書の下書きを作成してください。
+相談記録のAI要約と提案された支援メニューを踏まえ、具体的な長期・短期目標と支援内容を提案してください。`;
+
+  const result = await generativeModel.generateContent({
+    contents: [{ role: "user", parts: [{ text: userPrompt }] }],
+    systemInstruction: { role: "system", parts: [{ text: SYSTEM_INSTRUCTION_SUPPORT_PLAN }] },
+    generationConfig: {
+      responseMimeType: "application/json",
+      temperature: 0.4,
+      maxOutputTokens: 8192,
+    },
+  });
+
+  const candidate = result.response.candidates?.[0];
+  const responseText = candidate?.content?.parts?.[0]?.text;
+  if (!responseText) {
+    console.error("Vertex AI empty support plan response", JSON.stringify({
+      finishReason: candidate?.finishReason,
+      safetyRatings: candidate?.safetyRatings,
+      candidatesCount: result.response.candidates?.length ?? 0,
+    }));
+  }
+  return parseAIResponse<AISupportPlanResult>(responseText, ["overallPolicy", "goals", "specialNotes"]);
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -100,6 +100,42 @@ export interface AudioAnalysisResult extends AISummaryResult {
   transcript: string;
 }
 
+// 個別支援計画書
+export type SupportPlanStatus = "draft" | "confirmed";
+
+export interface SupportPlanGoal {
+  area: string; // 支援領域（例: 日常生活、健康管理、社会参加）
+  longTermGoal: string; // 長期目標
+  shortTermGoal: string; // 短期目標
+  supports: string[]; // 具体的な支援内容
+  frequency: string; // 支援頻度
+  responsible: string; // 担当者・機関
+}
+
+export interface SupportPlan {
+  id?: string;
+  caseId: string;
+  staffId: string; // 作成者
+  status: SupportPlanStatus;
+  clientName: string;
+  clientId: string;
+  overallPolicy: string; // 全体的な支援方針
+  goals: SupportPlanGoal[]; // 目標・支援内容一覧
+  specialNotes: string; // 特記事項
+  planStartDate: string; // 計画開始日（YYYY-MM-DD）
+  nextReviewDate: string; // 次回見直し日（YYYY-MM-DD）
+  confirmedAt?: Timestamp; // 確定日時
+  createdAt: Timestamp;
+  updatedAt: Timestamp;
+}
+
+// AI生成の支援計画下書きレスポンス
+export interface AISupportPlanResult {
+  overallPolicy: string;
+  goals: SupportPlanGoal[];
+  specialNotes: string;
+}
+
 // 対応する音声フォーマット
 export const SUPPORTED_AUDIO_MIME_TYPES = [
   "audio/wav",


### PR DESCRIPTION
## Summary
- **BE**: SupportPlan型・リポジトリ・Zodスキーマ・4エンドポイント（POST draft/GET/GET list/PATCH）
- **AI**: 厚労省マニュアル準拠プロンプトでICF視点の支援計画下書き生成（gemini-2.5-flash, temp 0.4）
- **FE**: SupportPlanViewコンポーネント（生成→編集→確定フロー）、CaseDetailにタブUI追加
- **セキュリティ**: Firestoreルールにsupportplansサブコレクション追加（担当者/admin ACL、delete禁止）
- **品質**: /simplify実施（並列ロード最適化、冗長state除去、CSS共通化、プロンプト最適化）

Closes #102

## 変更ファイル（14件）
| ファイル | 変更 |
|---------|------|
| `src/types.ts` | SupportPlan/SupportPlanGoal/AISupportPlanResult型 |
| `src/repositories/support-plan-repository.ts` | Firestore CRUD（subcollection） |
| `src/services/ai.ts` | generateSupportPlanDraft追加 |
| `src/schemas/case.ts` | updateSupportPlanSchema（Zod） |
| `src/routes/support-plans.ts` | 4エンドポイント |
| `src/routes/cases.ts` | support-planルート委譲 |
| `src/server.test.ts` | 統合テスト11件追加 |
| `firestore/firestore.rules` | supportPlans ACL |
| `firestore/firestore.rules.test.ts` | ルールテスト7件追加 |
| `frontend/src/api.ts` | SupportPlan型・API 3メソッド |
| `frontend/src/components/SupportPlanView.tsx` | 計画書UI（生成/編集/確定） |
| `frontend/src/pages/CaseDetail.tsx` | タブUI・並列データロード |
| `frontend/src/index.css` | タブ共通化・計画書スタイル |
| `frontend/src/test-setup.ts` | モック追加 |

## Test plan
- [x] BE統合テスト: POST draft（正常/400/403）、GET（正常/404）、PATCH（更新/確定/400/404）、GET list
- [x] Firestoreルール: 担当者read/create、非担当者拒否、admin更新、削除禁止
- [x] 全テスト330件パス（BE: 190, FE: 139, +既存static 1件失敗）
- [x] TypeScript/Vite build通過
- [ ] ブラウザ動作確認（CaseDetail→支援計画書タブ→AI生成→編集→確定）

🤖 Generated with [Claude Code](https://claude.com/claude-code)