### PR TITLE
fix: LegalSearchViewにkey propを追加（ケース切替対応）

### DIFF
--- a/frontend/src/pages/CaseDetail.tsx
+++ b/frontend/src/pages/CaseDetail.tsx
@@ -149,7 +149,7 @@ export function CaseDetail() {
             )}
 
             {activeTab === "legal-search" && (
-              <LegalSearchView caseId={id!} />
+              <LegalSearchView key={id} caseId={id!} />
             )}
 
             {activeTab === "consultations" && (


### PR DESCRIPTION
## Summary

- LegalSearchViewに`key={id}`を追加し、ケース切替時にコンポーネントが再マウントされるよう修正
- これにより前のケースのstateが残るバグを解消

## Test plan

- [x] `npm test` → 219 passed
- [x] `cd frontend && npx vitest run` → 147 passed
- [x] `npm run build` → TypeScriptエラーなし

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved case navigation to ensure proper state refresh when switching between different cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->