### PR TITLE
feat: legalSearches Firestoreセキュリティルール追加

### DIFF
--- a/firestore/firestore.rules
+++ b/firestore/firestore.rules
@@ -44,6 +44,17 @@ service cloud.firestore {
         allow delete: if false;
       }
 
+      // 法令検索（サブコレクション）: 親ケースの担当職員 or admin
+      match /legalSearches/{searchId} {
+        allow read: if request.auth != null
+          && (isAdmin() || get(/databases/$(database)/documents/cases/$(caseId)).data.assignedStaffId == request.auth.uid);
+        allow create: if request.auth != null
+          && (isAdmin() || get(/databases/$(database)/documents/cases/$(caseId)).data.assignedStaffId == request.auth.uid);
+        allow update: if request.auth != null
+          && (isAdmin() || get(/databases/$(database)/documents/cases/$(caseId)).data.assignedStaffId == request.auth.uid);
+        allow delete: if false;
+      }
+
       // 相談記録（サブコレクション）: 親ケースの担当職員 or admin
       match /consultations/{consultationId} {
         allow read: if request.auth != null

--- a/firestore/firestore.rules.test.ts
+++ b/firestore/firestore.rules.test.ts
@@ -323,6 +323,85 @@ describe("consultations", () => {
 });
 
 // ============================================================
+// legalSearches サブコレクション
+// ============================================================
+describe("legalSearches", () => {
+  async function setupLegalSearchData(caseId: string, searchId: string, assignedStaffId: string) {
+    await setupCaseData(caseId, assignedStaffId);
+    await testEnv.withSecurityRulesDisabled(async (context) => {
+      const db = context.firestore();
+      await setDoc(doc(db, "cases", caseId, "legalSearches", searchId), {
+        staffId: assignedStaffId,
+        query: "生活保護の申請要件",
+        references: [],
+        legalBasis: "テスト",
+        createdAt: new Date(),
+      });
+    });
+  }
+
+  it("未認証ユーザーは法令検索を読み取れない", async () => {
+    await setupLegalSearchData("case-1", "search-1", STAFF_UID);
+    const db = unauthContext().firestore();
+    await assertFails(getDoc(doc(db, "cases", "case-1", "legalSearches", "search-1")));
+  });
+
+  it("親ケース担当者は法令検索を読み取れる", async () => {
+    await setupLegalSearchData("case-1", "search-1", STAFF_UID);
+    const db = staffContext(STAFF_UID).firestore();
+    await assertSucceeds(getDoc(doc(db, "cases", "case-1", "legalSearches", "search-1")));
+  });
+
+  it("非担当者は法令検索を読み取れない", async () => {
+    await setupLegalSearchData("case-1", "search-1", STAFF_UID);
+    const db = staffContext(OTHER_STAFF_UID).firestore();
+    await assertFails(getDoc(doc(db, "cases", "case-1", "legalSearches", "search-1")));
+  });
+
+  it("親ケース担当者は法令検索を作成できる", async () => {
+    await setupCaseData("case-1", STAFF_UID);
+    const db = staffContext(STAFF_UID).firestore();
+    await assertSucceeds(addDoc(collection(db, "cases", "case-1", "legalSearches"), {
+      staffId: STAFF_UID,
+      query: "テスト検索",
+      references: [],
+      legalBasis: "テスト",
+      createdAt: new Date(),
+    }));
+  });
+
+  it("非担当者は法令検索を作成できない", async () => {
+    await setupCaseData("case-1", STAFF_UID);
+    const db = staffContext(OTHER_STAFF_UID).firestore();
+    await assertFails(addDoc(collection(db, "cases", "case-1", "legalSearches"), {
+      staffId: OTHER_STAFF_UID,
+      query: "不正検索",
+      references: [],
+      legalBasis: "テスト",
+      createdAt: new Date(),
+    }));
+  });
+
+  it("adminは法令検索を作成できる", async () => {
+    await setupCaseData("case-1", STAFF_UID);
+    const db = adminContext().firestore();
+    await assertSucceeds(addDoc(collection(db, "cases", "case-1", "legalSearches"), {
+      staffId: ADMIN_UID,
+      query: "管理者検索",
+      references: [],
+      legalBasis: "テスト",
+      createdAt: new Date(),
+    }));
+  });
+
+  it("法令検索の削除は禁止", async () => {
+    await setupLegalSearchData("case-1", "search-1", STAFF_UID);
+    const db = staffContext(STAFF_UID).firestore();
+    await assertFails(deleteDoc(doc(db, "cases", "case-1", "legalSearches", "search-1")));
+  });
+});
+
+// ============================================================
 // staff コレクション
 // ============================================================
 describe("staff", () => {


### PR DESCRIPTION
## Summary

- `legalSearches`サブコレクションのFirestoreセキュリティルールを追加
- 親ケースの担当職員 or adminのみread/create/update許可、delete禁止
- 既存のsupportPlans/monitoringSheets/consultationsと同一パターン
- テスト7件追加

## Test plan

- [x] `npm test` → 219 passed
- [x] `npm run build` → TypeScriptエラーなし
- [ ] `npm run test:rules` → emulatorが必要（ローカル確認用）
- [ ] `firebase deploy --only firestore` → 本番デプロイ後に動作確認

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced legal searches functionality enabling authorized users to create and manage legal search records with metadata tracking
  * Implemented role-based access controls restricting visibility and modifications to assigned case staff and administrators
  * Delete operations restricted to ensure data protection and system integrity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->