### PR TITLE
feat: プロンプトサイズ制限（相談要約の上限バウンディング）

### DIFF
--- a/src/routes/legal-search.ts
+++ b/src/routes/legal-search.ts
@@ -21,12 +21,17 @@ legalSearchRouter.post("/", async (req: Request, res: Response) => {
   }
 
   try {
-    // 相談記録を収集して検索コンテキストに使用
+    // 相談記録を収集して検索コンテキストに使用（直近20件・4000文字以内）
     const consultations = await consultationRepo.listConsultations(caseId);
-    const summaries = consultations
+    const completed = consultations
       .filter((c) => c.aiStatus === "completed" && c.summary)
-      .map((c) => `[${c.consultationType}] ${c.summary}`)
-      .join("\n");
+      .slice(-20);
+    let summaries = "";
+    for (const c of completed) {
+      const line = `[${c.consultationType}] ${c.summary}\n`;
+      if (summaries.length + line.length > 4000) break;
+      summaries += line;
+    }
 
     const aiResult = await searchLegalInfo(parsed.data.query, summaries);
 

--- a/src/services/ai.ts
+++ b/src/services/ai.ts
@@ -45,20 +45,34 @@ function buildMenuList(menus: SupportMenu[]): string {
     .join("\n");
 }
 
+// プロンプトサイズ制限: 直近N件・最大文字数で切り詰め
+const MAX_CONSULTATIONS = 20;
+const MAX_SUMMARY_CHARS = 8000;
+
 function buildConsultationSummaries(consultations: Consultation[]): string {
-  return consultations
+  const completed = consultations
     .filter((c) => c.aiStatus === "completed" && c.summary)
-    .map((c) => {
-      const supports = c.suggestedSupports
-        .map((s) => `  - ${s.menuName}（${s.reason}、関連度: ${Math.round(s.relevanceScore * 100)}%）`)
-        .join("\n");
-      return `### ${c.consultationType} 相談（${c.createdAt}）
+    .slice(-MAX_CONSULTATIONS); // 直近N件（時系列の末尾を優先）
+
+  const parts: string[] = [];
+  let totalLength = 0;
+
+  for (const c of completed) {
+    const supports = c.suggestedSupports
+      .map((s) => `  - ${s.menuName}（${s.reason}、関連度: ${Math.round(s.relevanceScore * 100)}%）`)
+      .join("\n");
+    const part = `### ${c.consultationType} 相談（${c.createdAt}）
 内容: ${c.content}
 AI要約: ${c.summary}
 提案された支援メニュー:
 ${supports || "  なし"}`;
-    })
-    .join("\n\n");
+
+    if (totalLength + part.length > MAX_SUMMARY_CHARS) break;
+    parts.push(part);
+    totalLength += part.length;
+  }
+
+  return parts.join("\n\n");
 }
 
 function parseAIResponse<T>(responseText: string | undefined, requiredFields: string[]): T {


### PR DESCRIPTION
## Summary

- `buildConsultationSummaries`: 直近20件・8000文字以内に制限（支援計画書・モニタリング用）
- 法令検索ルート: 直近20件・4000文字以内に制限
- 大量の相談記録がある場合のトークン制限超過リスクを防止

## Test plan

- [x] `npm test` → 219 passed
- [x] `cd frontend && npx vitest run` → 147 passed
- [x] `npm run build` → TypeScriptエラーなし

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)