### PR TITLE
feat: 新規ケース作成モーダルのUX改善

### DIFF
--- a/frontend/src/components/NewCaseModal.test.tsx
+++ b/frontend/src/components/NewCaseModal.test.tsx
@@ -211,16 +211,16 @@ describe("NewCaseModal", () => {
     });
   });
 
-  describe("無効ボタンのヒント", () => {
-    it("必須項目未入力時にボタンのtitle属性で理由を表示する", () => {
+  describe("未入力ヒント", () => {
+    it("必須項目未入力時に未入力項目を可視テキストで表示する", () => {
       renderModal();
 
-      const submitBtn = screen.getByText("ケースを作成");
-      expect(submitBtn).toHaveAttribute("title");
-      expect(submitBtn.getAttribute("title")).toMatch(/未入力/);
+      const hint = screen.getByText(/未入力の項目/);
+      expect(hint).toBeInTheDocument();
+      expect(hint.textContent).toMatch(/相談者氏名/);
     });
 
-    it("全項目入力後はtitle属性が消える", async () => {
+    it("全項目入力後は未入力ヒントが消える", async () => {
       renderModal();
       const user = userEvent.setup();
 
@@ -229,8 +229,7 @@ describe("NewCaseModal", () => {
       const dateInput = document.querySelector('input[type="date"]') as HTMLInputElement;
       await user.type(dateInput, "1990-01-01");
 
-      const submitBtn = screen.getByText("ケースを作成");
-      expect(submitBtn).not.toHaveAttribute("title");
+      expect(screen.queryByText(/未入力の項目/)).not.toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/components/NewCaseModal.tsx
+++ b/frontend/src/components/NewCaseModal.tsx
@@ -46,7 +46,7 @@ export function NewCaseModal({ onClose, onCreated }: Props) {
           <button className="btn btn-ghost" onClick={onClose}>✕</button>
         </div>
         <div className="modal-body">
-          {error && <div className="login-error">{error}</div>}
+          {error && <div className="form-error">{error}</div>}
 
           <div className="form-group">
             <label className="form-label">相談者氏名 *</label>
@@ -87,10 +87,12 @@ export function NewCaseModal({ onClose, onCreated }: Props) {
             className="btn btn-primary"
             onClick={handleSubmit}
             disabled={submitting || !isValid}
-            {...(!isValid ? { title: `未入力の項目: ${missingFields.join("、")}` } : {})}
           >
             {submitting ? "作成中..." : "ケースを作成"}
           </button>
+          {!isValid && (
+            <p className="form-help">未入力の項目: {missingFields.join("、")}</p>
+          )}
         </div>
       </div>
     </div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1066,7 +1066,7 @@ a:hover { color: var(--ai-600); }
   font-size: var(--text-sm);
 }
 
-.login-error, .alert-error {
+.login-error, .alert-error, .form-error {
   background: var(--kuri-100);
   color: var(--kuri-500);
   border: 1px solid rgba(196, 92, 92, 0.2);


### PR DESCRIPTION
## Summary
- 「相談者ID」ラベルに補足説明（住基番号・通所者番号等）とplaceholder改善
- 担当職員フィールドに自動割当の説明テキスト追加
- `alert()` → インラインエラー表示に変更（再送信時にクリア）
- 無効ボタンに `title` 属性で未入力項目を表示
- `.form-help` CSSスタイル追加

## Test plan
- [x] `npm test` → BE 219 passed
- [x] `cd frontend && npx vitest run` → FE 196 passed（+7件）
- [x] `npm run build` → TypeScript エラーなし
- [x] `npm run lint` → エラーなし

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)