### PR TITLE
feat: 相談記録作成モーダルのUX改善

### DIFF
--- a/frontend/src/components/NewConsultationModal.test.tsx
+++ b/frontend/src/components/NewConsultationModal.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { NewConsultationModal } from "./NewConsultationModal";
 import { TestAuthWrapper } from "../test-utils";
@@ -10,6 +10,7 @@ import { MockMediaRecorder } from "../__mocks__/MockMediaRecorder";
 beforeEach(() => {
   vi.mocked(api.createConsultation).mockReset();
   vi.mocked(api.createAudioConsultation).mockReset();
+  vi.mocked(api.getConsultation).mockReset();
   vi.stubGlobal("MediaRecorder", MockMediaRecorder);
 });
 
@@ -158,26 +159,21 @@ describe("NewConsultationModal", () => {
     renderModal();
     const user = userEvent.setup();
 
-    // Switch to audio mode, then file sub-mode
     await user.click(screen.getByText("音声"));
     await user.click(screen.getByText(/ファイルを選択/));
-
-    // Simulate file selection
     const file = new File(["audio-data"], "test.wav", { type: "audio/wav" });
     const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
     await user.upload(fileInput, file);
 
-    // Submit
     await user.click(screen.getByText("音声を分析・記録"));
 
-    // Should show AI results
     await vi.waitFor(() => {
       expect(screen.getByText("AI分析結果")).toBeInTheDocument();
     });
     expect(screen.getByText("音声のテキスト")).toBeInTheDocument();
     expect(screen.getByText("AI要約テスト")).toBeInTheDocument();
     expect(screen.getByText("生活保護")).toBeInTheDocument();
-    expect(screen.getByText("90")).toBeInTheDocument(); // relevanceScore * 100
+    expect(screen.getByText("90")).toBeInTheDocument();
   });
 
   it("calls onClose when cancel is clicked", async () => {
@@ -214,7 +210,6 @@ describe("NewConsultationModal", () => {
 
     await user.click(screen.getByText("音声"));
 
-    // Should show file upload directly without toggle
     expect(screen.getByText(/クリックして音声ファイルを選択/)).toBeInTheDocument();
     expect(screen.queryByText(/録音する/)).not.toBeInTheDocument();
   });
@@ -223,16 +218,138 @@ describe("NewConsultationModal", () => {
     renderModal();
     const user = userEvent.setup();
 
-    // Switch to audio → file sub-mode
     await user.click(screen.getByText("音声"));
     await user.click(screen.getByText(/ファイルを選択/));
     expect(screen.getByText(/クリックして音声ファイルを選択/)).toBeInTheDocument();
 
-    // Switch to text
     await user.click(screen.getByText("テキスト入力"));
 
-    // Switch back to audio → should default to record, not file
     await user.click(screen.getByText("音声"));
     expect(screen.getByText("録音開始")).toBeInTheDocument();
+  });
+
+  // ===== Issue #121 UX改善テスト =====
+
+  describe("相談種別の説明", () => {
+    it("相談種別に説明文を表示する", () => {
+      renderModal();
+
+      expect(screen.getByText(/対面での相談/)).toBeInTheDocument();
+    });
+  });
+
+  describe("文字数カウンター", () => {
+    it("テキストモードで文字数カウンターを表示する", async () => {
+      renderModal();
+      const user = userEvent.setup();
+
+      await user.type(screen.getByPlaceholderText(/相談者の状況/), "テスト");
+
+      expect(screen.getByText(/3文字/)).toBeInTheDocument();
+    });
+
+    it("空の状態では0文字と表示する", () => {
+      renderModal();
+
+      expect(screen.getByText(/0文字/)).toBeInTheDocument();
+    });
+  });
+
+  describe("インラインエラー表示", () => {
+    it("テキスト送信失敗時にインラインエラーを表示する（alertではない）", async () => {
+      vi.mocked(api.createConsultation).mockRejectedValue(new Error("Network error"));
+      const alertMock = vi.spyOn(window, "alert").mockImplementation(() => {});
+
+      renderModal();
+      const user = userEvent.setup();
+
+      await user.type(screen.getByPlaceholderText(/相談者の状況/), "テスト内容");
+      await user.click(screen.getByText("相談を記録"));
+
+      await waitFor(() => {
+        expect(screen.getByText(/送信に失敗しました/)).toBeInTheDocument();
+      });
+
+      expect(alertMock).not.toHaveBeenCalled();
+      alertMock.mockRestore();
+    });
+
+    it("再送信時にエラーがクリアされる", async () => {
+      vi.mocked(api.createConsultation)
+        .mockRejectedValueOnce(new Error("Network error"))
+        .mockResolvedValueOnce({
+          id: "cons-1",
+          caseId: "case-1",
+          staffId: "test-staff-001",
+          content: "テスト内容",
+          transcript: "",
+          summary: "",
+          suggestedSupports: [],
+          consultationType: "counter",
+          aiStatus: "completed",
+          createdAt: { _seconds: 1700000000 },
+          updatedAt: { _seconds: 1700000000 },
+        });
+
+      renderModal();
+      const user = userEvent.setup();
+
+      await user.type(screen.getByPlaceholderText(/相談者の状況/), "テスト内容");
+      await user.click(screen.getByText("相談を記録"));
+
+      await waitFor(() => {
+        expect(screen.getByText(/送信に失敗しました/)).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByText("相談を記録"));
+
+      await waitFor(() => {
+        expect(screen.queryByText(/送信に失敗しました/)).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("ファイルアップロードUI", () => {
+    it("ファイルアップロード領域にボタンスタイルのテキストを表示する", async () => {
+      renderModal();
+      const user = userEvent.setup();
+
+      await user.click(screen.getByText("音声"));
+      await user.click(screen.getByText(/ファイルを選択/));
+
+      expect(screen.getByText(/ファイルを選ぶ/)).toBeInTheDocument();
+    });
+  });
+
+  describe("ポーリングエラー表示", () => {
+    it("AI分析中画面でポーリングエラーフラグが立つとメッセージ表示する", async () => {
+      vi.mocked(api.createAudioConsultation).mockResolvedValue({
+        id: "cons-1",
+        caseId: "case-1",
+        staffId: "test-staff-001",
+        content: "",
+        transcript: "",
+        summary: "",
+        suggestedSupports: [],
+        consultationType: "counter",
+        aiStatus: "pending",
+        createdAt: { _seconds: 1700000000 },
+        updatedAt: { _seconds: 1700000000 },
+      });
+
+      renderModal();
+      const user = userEvent.setup();
+
+      await user.click(screen.getByText("音声"));
+      await user.click(screen.getByText(/ファイルを選択/));
+      const file = new File(["audio-data"], "test.wav", { type: "audio/wav" });
+      const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+      await user.upload(fileInput, file);
+      await user.click(screen.getByText("音声を分析・記録"));
+
+      await waitFor(() => {
+        expect(screen.getByText(/AI分析中/)).toBeInTheDocument();
+      });
+    });
   });
 });

--- a/frontend/src/components/NewConsultationModal.tsx
+++ b/frontend/src/components/NewConsultationModal.tsx
@@ -17,12 +17,19 @@ type AudioSource = "record" | "file";
 
 const POLL_INTERVAL_MS = 5000;
 const POLL_MAX_ATTEMPTS = 60; // 5分間
+const POLL_TIMEOUT_WARNING = 48; // 4分経過で警告
+
+const CONSULTATION_TYPE_LABELS: Record<string, string> = {
+  counter: "窓口 — 対面での相談",
+  visit: "訪問 — 相談者宅等への訪問",
+  phone: "電話 — 電話による相談",
+  online: "オンライン — ビデオ通話等",
+};
 
 export function NewConsultationModal({ caseId, onClose, onCreated }: Props) {
   const { user } = useAuth();
   const [mode, setMode] = useState<Mode>("text");
   const [audioSource, setAudioSource] = useState<AudioSource>("record");
-  // Fall back to file upload when browser doesn't support recording
   const [form, setForm] = useState({
     content: "",
     consultationType: "counter",
@@ -30,28 +37,32 @@ export function NewConsultationModal({ caseId, onClose, onCreated }: Props) {
   });
   const [audioFile, setAudioFile] = useState<File | null>(null);
   const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState("");
   const [audioConsultation, setAudioConsultation] = useState<Consultation | null>(null);
   const [pollCount, setPollCount] = useState(0);
+  const [pollError, setPollError] = useState(false);
   const pollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const recorder = useAudioRecorder();
   const effectiveAudioSource = recorder.isSupported ? audioSource : "file";
 
-  // Use recorded file or uploaded file
   const activeAudioFile = effectiveAudioSource === "record" ? recorder.recordedFile : audioFile;
 
-  // ポーリングで音声相談のAI分析状態を監視
   const pollStatus = useCallback(async (consultation: Consultation, attempt: number) => {
     if (attempt >= POLL_MAX_ATTEMPTS) return;
     try {
       const updated = await api.getConsultation(caseId, consultation.id!);
       setAudioConsultation(updated);
+      setPollError(false);
       if (updated.aiStatus === "pending" || updated.aiStatus === "retrying" || updated.aiStatus === "retry_pending") {
         setPollCount(attempt + 1);
         pollTimerRef.current = setTimeout(() => pollStatus(updated, attempt + 1), POLL_INTERVAL_MS);
       }
     } catch {
-      // ポーリング失敗は無視（次回リフレッシュで確認可能）
+      setPollError(true);
+      // リトライ継続
+      setPollCount(attempt + 1);
+      pollTimerRef.current = setTimeout(() => pollStatus(consultation, attempt + 1), POLL_INTERVAL_MS);
     }
   }, [caseId]);
 
@@ -63,6 +74,7 @@ export function NewConsultationModal({ caseId, onClose, onCreated }: Props) {
 
   const handleSubmit = async () => {
     setSubmitting(true);
+    setError("");
     try {
       if (mode === "text") {
         await api.createConsultation(caseId, {
@@ -79,11 +91,11 @@ export function NewConsultationModal({ caseId, onClose, onCreated }: Props) {
         const result = await api.createAudioConsultation(caseId, formData);
         setAudioConsultation(result);
         setPollCount(0);
-        // AI分析はpendingで返るのでポーリング開始
+        setPollError(false);
         pollTimerRef.current = setTimeout(() => pollStatus(result, 0), POLL_INTERVAL_MS);
       }
     } catch (err) {
-      alert(`送信に失敗しました: ${(err as Error).message}`);
+      setError(`送信に失敗しました: ${(err as Error).message}`);
     } finally {
       setSubmitting(false);
     }
@@ -112,6 +124,14 @@ export function NewConsultationModal({ caseId, onClose, onCreated }: Props) {
                   AI分析を実行中です...（{pollCount * 5}秒経過）
                 </div>
                 <p className="ai-summary">音声の文字起こしと分析を行っています。このまましばらくお待ちください。画面を閉じても分析は継続されます。</p>
+                {pollError && (
+                  <p className="form-error">接続に問題があります。自動的に再試行しています。</p>
+                )}
+                {pollCount >= POLL_TIMEOUT_WARNING && (
+                  <p className="form-help" style={{ color: "var(--kuri-500)" }}>
+                    分析に時間がかかっています。画面を閉じて後で確認することもできます。
+                  </p>
+                )}
               </div>
             )}
 
@@ -178,6 +198,8 @@ export function NewConsultationModal({ caseId, onClose, onCreated }: Props) {
           <button className="btn btn-ghost" onClick={onClose}>✕</button>
         </div>
         <div className="modal-body">
+          {error && <div className="form-error">{error}</div>}
+
           {/* Mode Toggle */}
           <div className="mode-toggle">
             <button
@@ -206,10 +228,9 @@ export function NewConsultationModal({ caseId, onClose, onCreated }: Props) {
                 value={form.consultationType}
                 onChange={(e) => setForm({ ...form, consultationType: e.target.value })}
               >
-                <option value="counter">窓口</option>
-                <option value="visit">訪問</option>
-                <option value="phone">電話</option>
-                <option value="online">オンライン</option>
+                {Object.entries(CONSULTATION_TYPE_LABELS).map(([value, label]) => (
+                  <option key={value} value={value}>{label}</option>
+                ))}
               </select>
             </div>
           </div>
@@ -224,6 +245,7 @@ export function NewConsultationModal({ caseId, onClose, onCreated }: Props) {
                 placeholder="相談者の状況や相談内容を記録してください..."
                 rows={6}
               />
+              <p className="form-help">{form.content.length}文字</p>
             </div>
           ) : (
             <>
@@ -327,7 +349,7 @@ export function NewConsultationModal({ caseId, onClose, onCreated }: Props) {
                     onChange={(e) => setAudioFile(e.target.files?.[0] ?? null)}
                   />
                   <div
-                    className={`audio-recorder ${audioFile ? "has-file" : ""}`}
+                    className={`audio-recorder file-upload-area ${audioFile ? "has-file" : ""}`}
                     onClick={() => fileInputRef.current?.click()}
                   >
                     <div className="audio-icon">{audioFile ? "✅" : "📁"}</div>
@@ -341,6 +363,11 @@ export function NewConsultationModal({ caseId, onClose, onCreated }: Props) {
                       <div className="audio-filename">
                         {audioFile.name} ({(audioFile.size / 1024 / 1024).toFixed(1)} MB)
                       </div>
+                    )}
+                    {!audioFile && (
+                      <span className="btn btn-secondary btn-sm" style={{ marginTop: "var(--space-2)" }}>
+                        ファイルを選ぶ
+                      </span>
                     )}
                   </div>
                 </div>

--- a/frontend/src/hooks/useAudioRecorder.test.ts
+++ b/frontend/src/hooks/useAudioRecorder.test.ts
@@ -127,7 +127,7 @@ describe("useAudioRecorder", () => {
     });
 
     expect(result.current.isRecording).toBe(false);
-    expect(result.current.error).toBe("マイクへのアクセスが許可されていません。ブラウザの設定を確認してください。");
+    expect(result.current.error).toBe("マイクへのアクセスが許可されていません。アドレスバーのカメラ/マイクアイコンから許可するか、ブラウザの設定 > プライバシー > マイクで許可してください。");
   });
 
   it("sets generic error for non-permission failures", async () => {

--- a/frontend/src/hooks/useAudioRecorder.ts
+++ b/frontend/src/hooks/useAudioRecorder.ts
@@ -128,7 +128,7 @@ export function useAudioRecorder(): AudioRecorderState & AudioRecorderActions {
       // Abort if session was superseded
       if (sessionIdRef.current !== currentSession) return;
       const msg = err instanceof DOMException && err.name === "NotAllowedError"
-        ? "マイクへのアクセスが許可されていません。ブラウザの設定を確認してください。"
+        ? "マイクへのアクセスが許可されていません。アドレスバーのカメラ/マイクアイコンから許可するか、ブラウザの設定 > プライバシー > マイクで許可してください。"
         : "マイクの初期化に失敗しました。";
       setError(msg);
       releaseStream();


### PR DESCRIPTION
## Summary
- 相談種別に説明テキスト追加（窓口=対面、訪問=宅訪問等）
- テキスト入力に文字数カウンター追加
- `alert()` → インラインエラー表示（再送信時クリア）
- マイク許可エラーに具体的な手順追加
- ファイルアップロード領域にボタンスタイル追加
- ポーリング失敗時のエラーメッセージ表示
- タイムアウト接近時（4分経過）の警告メッセージ

## Test plan
- [x] `npm test` → BE 219 passed
- [x] `cd frontend && npx vitest run` → FE 203 passed（+7件）
- [x] `npm run build` → TypeScript エラーなし
- [x] `npm run lint` → エラーなし

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)