### PR TITLE
fix: ポーリングエラーの恒久/一時分類

### DIFF
--- a/frontend/src/components/NewConsultationModal.test.tsx
+++ b/frontend/src/components/NewConsultationModal.test.tsx
@@ -4,7 +4,7 @@ import userEvent from "@testing-library/user-event";
 import { NewConsultationModal } from "./NewConsultationModal";
 import { TestAuthWrapper } from "../test-utils";
 
-import { api } from "../api";
+import { api, ApiError } from "../api";
 import { MockMediaRecorder } from "../__mocks__/MockMediaRecorder";
 
 beforeEach(() => {
@@ -322,34 +322,116 @@ describe("NewConsultationModal", () => {
   });
 
   describe("ポーリングエラー表示", () => {
-    it("AI分析中画面でポーリングエラーフラグが立つとメッセージ表示する", async () => {
-      vi.mocked(api.createAudioConsultation).mockResolvedValue({
-        id: "cons-1",
-        caseId: "case-1",
-        staffId: "test-staff-001",
-        content: "",
-        transcript: "",
-        summary: "",
-        suggestedSupports: [],
-        consultationType: "counter",
-        aiStatus: "pending",
-        createdAt: { _seconds: 1700000000 },
-        updatedAt: { _seconds: 1700000000 },
-      });
+    const pendingConsultation = {
+      id: "cons-1",
+      caseId: "case-1",
+      staffId: "test-staff-001",
+      content: "",
+      transcript: "",
+      summary: "",
+      suggestedSupports: [],
+      consultationType: "counter",
+      aiStatus: "pending" as const,
+      createdAt: { _seconds: 1700000000 },
+      updatedAt: { _seconds: 1700000000 },
+    };
 
+    async function submitAudioAndStartPolling() {
+      vi.mocked(api.createAudioConsultation).mockResolvedValue(pendingConsultation);
       renderModal();
       const user = userEvent.setup();
-
       await user.click(screen.getByText("音声"));
       await user.click(screen.getByText(/ファイルを選択/));
       const file = new File(["audio-data"], "test.wav", { type: "audio/wav" });
       const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
       await user.upload(fileInput, file);
       await user.click(screen.getByText("音声を分析・記録"));
-
       await waitFor(() => {
         expect(screen.getByText(/AI分析中/)).toBeInTheDocument();
       });
+    }
+
+    it("AI分析中画面でポーリングエラーフラグが立つとメッセージ表示する", async () => {
+      await submitAudioAndStartPolling();
+    });
+
+    it("一時エラー（5xx/ネットワーク）で再試行を継続する", async () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+      vi.mocked(api.getConsultation)
+        .mockRejectedValueOnce(new ApiError("Internal Server Error", "UNKNOWN", 500))
+        .mockResolvedValueOnce(pendingConsultation);
+
+      await submitAudioAndStartPolling();
+
+      // 1回目のポーリング: 500エラー → 再試行メッセージ表示
+      await vi.advanceTimersByTimeAsync(5000);
+      await waitFor(() => {
+        expect(screen.getByText(/接続に問題があります/)).toBeInTheDocument();
+      });
+
+      // 2回目のポーリング: 成功 → エラー表示消える
+      await vi.advanceTimersByTimeAsync(5000);
+      await waitFor(() => {
+        expect(screen.queryByText(/接続に問題があります/)).not.toBeInTheDocument();
+      });
+
+      vi.useRealTimers();
+    });
+
+    it("恒久エラー（403）でポーリングを停止しエラー表示する", async () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+      vi.mocked(api.getConsultation)
+        .mockRejectedValueOnce(new ApiError("Access denied", "EMAIL_DOMAIN_NOT_ALLOWED", 403));
+
+      await submitAudioAndStartPolling();
+
+      // 1回目のポーリング: 403 → 恒久エラー表示、再試行しない
+      await vi.advanceTimersByTimeAsync(5000);
+      await waitFor(() => {
+        expect(screen.getByText(/アクセスが拒否されました/)).toBeInTheDocument();
+      });
+      // 再試行メッセージは表示されない
+      expect(screen.queryByText(/自動的に再試行/)).not.toBeInTheDocument();
+
+      vi.useRealTimers();
+    });
+
+    it("恒久エラー（404）でポーリングを停止しエラー表示する", async () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+      vi.mocked(api.getConsultation)
+        .mockRejectedValueOnce(new ApiError("Not found", "UNKNOWN", 404));
+
+      await submitAudioAndStartPolling();
+
+      await vi.advanceTimersByTimeAsync(5000);
+      await waitFor(() => {
+        expect(screen.getByText(/アクセスが拒否されました/)).toBeInTheDocument();
+      });
+
+      vi.useRealTimers();
+    });
+
+    it("ネットワークエラー（statusなし）で再試行を継続する", async () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+      vi.mocked(api.getConsultation)
+        .mockRejectedValueOnce(new Error("Failed to fetch"))
+        .mockResolvedValueOnce(pendingConsultation);
+
+      await submitAudioAndStartPolling();
+
+      // ネットワークエラー → 再試行メッセージ
+      await vi.advanceTimersByTimeAsync(5000);
+      await waitFor(() => {
+        expect(screen.getByText(/接続に問題があります/)).toBeInTheDocument();
+      });
+
+      // 復旧 → エラー消える
+      await vi.advanceTimersByTimeAsync(5000);
+      await waitFor(() => {
+        expect(screen.queryByText(/接続に問題があります/)).not.toBeInTheDocument();
+      });
+
+      vi.useRealTimers();
     });
   });
 });

--- a/frontend/src/components/NewConsultationModal.tsx
+++ b/frontend/src/components/NewConsultationModal.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect, useCallback } from "react";
-import { api } from "../api";
+import { api, ApiError } from "../api";
 import type { Consultation } from "../api";
 import { useAuth } from "../contexts/AuthContext";
 import { SuggestedSupports } from "./SuggestedSupports";
@@ -41,6 +41,7 @@ export function NewConsultationModal({ caseId, onClose, onCreated }: Props) {
   const [audioConsultation, setAudioConsultation] = useState<Consultation | null>(null);
   const [pollCount, setPollCount] = useState(0);
   const [pollError, setPollError] = useState(false);
+  const [pollPermanentError, setPollPermanentError] = useState("");
   const pollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const recorder = useAudioRecorder();
@@ -58,9 +59,14 @@ export function NewConsultationModal({ caseId, onClose, onCreated }: Props) {
         setPollCount(attempt + 1);
         pollTimerRef.current = setTimeout(() => pollStatus(updated, attempt + 1), POLL_INTERVAL_MS);
       }
-    } catch {
+    } catch (err) {
+      // 恒久エラー（4xx、401除く）→ ポーリング停止+エラー表示
+      if (err instanceof ApiError && err.status >= 400 && err.status < 500 && err.status !== 401) {
+        setPollPermanentError("アクセスが拒否されました。画面を閉じてやり直してください。");
+        return;
+      }
+      // 一時エラー（5xx/ネットワーク）→ 再試行継続
       setPollError(true);
-      // リトライ継続
       setPollCount(attempt + 1);
       pollTimerRef.current = setTimeout(() => pollStatus(consultation, attempt + 1), POLL_INTERVAL_MS);
     }
@@ -92,6 +98,7 @@ export function NewConsultationModal({ caseId, onClose, onCreated }: Props) {
         setAudioConsultation(result);
         setPollCount(0);
         setPollError(false);
+        setPollPermanentError("");
         pollTimerRef.current = setTimeout(() => pollStatus(result, 0), POLL_INTERVAL_MS);
       }
     } catch (err) {
@@ -124,7 +131,10 @@ export function NewConsultationModal({ caseId, onClose, onCreated }: Props) {
                   AI分析を実行中です...（{pollCount * 5}秒経過）
                 </div>
                 <p className="ai-summary">音声の文字起こしと分析を行っています。このまましばらくお待ちください。画面を閉じても分析は継続されます。</p>
-                {pollError && (
+                {pollPermanentError && (
+                  <p className="form-error">{pollPermanentError}</p>
+                )}
+                {pollError && !pollPermanentError && (
                   <p className="form-error">接続に問題があります。自動的に再試行しています。</p>
                 )}
                 {pollCount >= POLL_TIMEOUT_WARNING && (


### PR DESCRIPTION
## Summary
- ポーリングの`catch`ブロックで`ApiError.status`を判定し、恒久エラー（4xx、401除く）と一時エラー（5xx/ネットワーク）を分類
- 恒久エラー時はポーリングを即停止し、ユーザーにエラーメッセージを表示
- 一時エラー時は従来通り再試行を継続
- テスト4件追加（403停止、404停止、5xx再試行、ネットワークエラー再試行）

## Test plan
- [x] `npm test` → BE 219 passed
- [x] `cd frontend && npx vitest run` → FE 216 passed

Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)