### PR TITLE
fix: サイドバーbutton要素のスタイルリセット

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -171,6 +171,10 @@ a:hover { color: var(--ai-600); }
   gap: var(--space-3);
   position: relative;
   cursor: pointer;
+  background: none;
+  border: none;
+  padding: 0;
+  text-align: left;
 }
 
 .sidebar-brand-icon {
@@ -211,6 +215,10 @@ a:hover { color: var(--ai-600); }
   margin-bottom: var(--space-1);
   position: relative;
   overflow: hidden;
+  background: none;
+  border: none;
+  width: 100%;
+  text-align: left;
 }
 
 .sidebar-nav-item::before {


### PR DESCRIPTION
## Summary
- PR #158 のa11y改善で `div` → `button` に変更したサイドバー要素に、ブラウザデフォルトスタイル（border, background, padding）のリセットが欠落していた
- `.sidebar-brand` と `.sidebar-nav-item` に `background: none; border: none; padding: 0; text-align: left; width: 100%` を追加

## Test plan
- [x] FEビルド成功
- [x] FEテスト 216件パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined sidebar brand and navigation item styling for a cleaner appearance and improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->