### PR TITLE
feat: 相談記録の編集・削除E2Eテスト追加 + ヘルプページ更新

### DIFF
--- a/e2e/case-consultation.spec.ts
+++ b/e2e/case-consultation.spec.ts
@@ -99,6 +99,52 @@ test.describe("ケース作成・相談記録フロー", () => {
     expect(selectedValue).toBe("counter");
   });
 
+  test("相談記録を編集して保存する", async ({ page }) => {
+    // ケース詳細に遷移
+    await page.locator(".case-card").first().click();
+    await expect(page.getByText("← ケース一覧に戻る")).toBeVisible();
+
+    // ⋯メニューを開く
+    const menuBtn = page.locator(".consultation-menu-btn").first();
+    await menuBtn.click();
+
+    // 編集を選択
+    await page.locator(".consultation-menu-dropdown button", { hasText: "編集" }).click();
+
+    // テキストエリアに変更を加える
+    const textarea = page.locator("textarea").first();
+    await expect(textarea).toBeVisible();
+    await textarea.fill("編集後のテスト相談内容");
+
+    // 保存ボタンをクリック
+    await page.getByRole("button", { name: "保存" }).click();
+
+    // 編集バッジ「（テスト職員 が編集）」が表示される
+    await expect(page.getByText(/テスト職員 が編集/)).toBeVisible({ timeout: 10000 });
+  });
+
+  test("相談記録を削除する", async ({ page }) => {
+    // ケース詳細に遷移
+    await page.locator(".case-card").first().click();
+    await expect(page.getByText("← ケース一覧に戻る")).toBeVisible();
+
+    // 相談記録が表示されていることを確認
+    await expect(page.getByText("テスト相談内容")).toBeVisible();
+
+    // confirmダイアログを自動でacceptする
+    page.on("dialog", (dialog) => dialog.accept());
+
+    // ⋯メニューを開く
+    const menuBtn = page.locator(".consultation-menu-btn").first();
+    await menuBtn.click();
+
+    // 削除を選択
+    await page.locator(".consultation-menu-dropdown button", { hasText: "削除" }).click();
+
+    // 相談記録が一覧から消えることを確認
+    await expect(page.getByText("テスト相談内容")).not.toBeVisible({ timeout: 10000 });
+  });
+
   test("ケース一覧に戻るリンクが機能する", async ({ page }) => {
     await page.locator(".case-card").first().click();
     await expect(page.getByText("← ケース一覧に戻る")).toBeVisible();

--- a/e2e/generate-help-screenshots.ts
+++ b/e2e/generate-help-screenshots.ts
@@ -156,6 +156,19 @@ test.describe("ヘルプ用スクリーンショット生成", () => {
     }
   });
 
+  test("7.5. 相談記録の編集メニュー", async ({ page }) => {
+    await page.getByText("山田 花子").click();
+    await page.locator(".consultation-timeline").waitFor({ timeout: 10000 });
+    // ⋯メニューをクリックして開いた状態でスクリーンショット
+    const menuBtn = page.locator(".consultation-menu-btn").first();
+    await menuBtn.click();
+    await page.locator(".consultation-menu-dropdown").waitFor({ timeout: 5000 });
+    await page.waitForTimeout(300);
+    await page.screenshot({
+      path: path.join(OUTPUT_DIR, "edit-consultation.png"),
+    });
+  });
+
   test("8. 支援計画書タブ", async ({ page }) => {
     await page.getByText("山田 花子").click();
     await page.locator(".consultation-timeline").waitFor({ timeout: 10000 });

--- a/e2e/help-page.spec.ts
+++ b/e2e/help-page.spec.ts
@@ -18,7 +18,7 @@ test.describe("ヘルプページ", () => {
     await expect(page.getByText("福祉相談業務支援システムの基本的な操作方法")).toBeVisible();
   });
 
-  test("全12セクションの見出しが表示される", async ({ page }) => {
+  test("全13セクションの見出しが表示される", async ({ page }) => {
     const expectedTitles = [
       "ダッシュボード（ケース一覧）",
       "新規ケースの作成",
@@ -27,6 +27,7 @@ test.describe("ヘルプページ", () => {
       "音声で相談を記録する（直接録音）",
       "音声で相談を記録する（ファイルアップロード）",
       "AI分析結果の見方",
+      "相談記録の編集・削除",
       "支援計画書の作成",
       "モニタリングシートの作成",
       "法令・制度の検索",
@@ -34,28 +35,29 @@ test.describe("ヘルプページ", () => {
       "アカウント管理",
     ];
     const headings = page.getByRole("heading", { level: 2 });
-    await expect(headings).toHaveCount(12);
+    await expect(headings).toHaveCount(13);
     for (const title of expectedTitles) {
       await expect(page.getByRole("heading", { level: 2, name: title })).toBeVisible();
     }
   });
 
-  test("目次に12のアンカーリンクが存在する", async ({ page }) => {
+  test("目次に13のアンカーリンクが存在する", async ({ page }) => {
     const toc = page.locator(".help-toc");
     await expect(toc).toBeVisible();
     const links = toc.locator("a");
-    await expect(links).toHaveCount(12);
+    await expect(links).toHaveCount(13);
     // 代表的なアンカーリンクを確認
     await expect(links.nth(0)).toHaveAttribute("href", "#dashboard");
     await expect(links.nth(6)).toHaveAttribute("href", "#ai-analysis");
-    await expect(links.nth(11)).toHaveAttribute("href", "#settings-accounts");
+    await expect(links.nth(7)).toHaveAttribute("href", "#edit-delete-consultation");
+    await expect(links.nth(12)).toHaveAttribute("href", "#settings-accounts");
   });
 
-  test("全12枚のスクリーンショット画像が読み込まれる", async ({ page }) => {
+  test("全13枚のスクリーンショット画像が読み込まれる", async ({ page }) => {
     const images = page.locator(".help-screenshot img");
-    await expect(images).toHaveCount(12);
+    await expect(images).toHaveCount(13);
     // 各画像をスクロールして表示し（lazy loading対応）、読み込みを確認
-    for (let i = 0; i < 12; i++) {
+    for (let i = 0; i < 13; i++) {
       const img = images.nth(i);
       await img.scrollIntoViewIfNeeded();
       // lazy loadの完了を待つ

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -391,7 +391,20 @@ export async function mockApiRoutesForHelp(page: Page) {
         route.fulfill({
           status: 200,
           contentType: "application/json",
-          body: JSON.stringify([DEMO_CONSULTATION]),
+          body: JSON.stringify([
+            DEMO_CONSULTATION,
+            {
+              ...DEMO_CONSULTATION,
+              id: "cons-demo-002",
+              content: "電話相談。山田さんより生活保護申請書類の進捗について連絡あり。年金振込通知書の取得方法について相談。",
+              summary: "生活保護申請書類の進捗確認。年金振込通知書の取得方法についての電話相談。",
+              consultationType: "phone",
+              editedAt: { _seconds: 1773244800 },
+              editedBy: "staff-demo-001",
+              createdAt: { _seconds: 1773072000 },
+              updatedAt: { _seconds: 1773244800 },
+            },
+          ]),
         });
       }
     }),
@@ -415,11 +428,37 @@ export async function mockApiRoutesForHelp(page: Page) {
         route.fallback();
         return;
       }
-      route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body: JSON.stringify({ ...DEMO_CONSULTATION, aiStatus: "completed" }),
-      });
+      const method = route.request().method();
+      if (method === "PATCH") {
+        try {
+          const body = JSON.parse(route.request().postData() || "{}");
+          route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify({
+              ...DEMO_CONSULTATION,
+              ...body,
+              aiStatus: "pending",
+              editedAt: { _seconds: Math.floor(Date.now() / 1000) },
+              editedBy: "staff-demo-001",
+            }),
+          });
+        } catch {
+          route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify(DEMO_CONSULTATION),
+          });
+        }
+      } else if (method === "DELETE") {
+        route.fulfill({ status: 204, body: "" });
+      } else {
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ ...DEMO_CONSULTATION, aiStatus: "completed" }),
+        });
+      }
     }),
 
     // 支援計画書
@@ -603,17 +642,43 @@ export async function mockApiRoutes(page: Page) {
       });
     }),
 
-    // GET /api/cases/:id/consultations/:cId (individual consultation for polling)
+    // GET/PATCH/DELETE /api/cases/:id/consultations/:cId
     page.route(/\/api\/cases\/[^/]+\/consultations\/[^/]+$/, (route) => {
       if (route.request().url().includes("/audio")) {
         route.fallback();
         return;
       }
-      route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body: JSON.stringify({ ...MOCK_CONSULTATION, aiStatus: "completed" }),
-      });
+      const method = route.request().method();
+      if (method === "PATCH") {
+        try {
+          const body = JSON.parse(route.request().postData() || "{}");
+          route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify({
+              ...MOCK_CONSULTATION,
+              ...body,
+              aiStatus: "pending",
+              editedAt: { _seconds: Math.floor(Date.now() / 1000) },
+              editedBy: "e2e-staff-001",
+            }),
+          });
+        } catch {
+          route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify(MOCK_CONSULTATION),
+          });
+        }
+      } else if (method === "DELETE") {
+        route.fulfill({ status: 204, body: "" });
+      } else {
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ ...MOCK_CONSULTATION, aiStatus: "completed" }),
+        });
+      }
     }),
 
     // POST /api/cases/:id/support-plan/draft + GET /api/cases/:id/support-plan

--- a/frontend/src/pages/Help.test.tsx
+++ b/frontend/src/pages/Help.test.tsx
@@ -19,11 +19,11 @@ describe("Help", () => {
     expect(screen.getByText(/福祉相談業務支援システム/)).toBeInTheDocument();
   });
 
-  it("renders all 12 section headings", () => {
+  it("renders all 13 section headings", () => {
     renderHelp();
 
     const headings = screen.getAllByRole("heading", { level: 2 });
-    expect(headings).toHaveLength(12);
+    expect(headings).toHaveLength(13);
     expect(headings[0]).toHaveTextContent("ダッシュボード（ケース一覧）");
     expect(headings[1]).toHaveTextContent("新規ケースの作成");
     expect(headings[2]).toHaveTextContent("ケース詳細の確認");
@@ -31,30 +31,32 @@ describe("Help", () => {
     expect(headings[4]).toHaveTextContent("音声で相談を記録する（直接録音）");
     expect(headings[5]).toHaveTextContent("音声で相談を記録する（ファイルアップロード）");
     expect(headings[6]).toHaveTextContent("AI分析結果の見方");
-    expect(headings[7]).toHaveTextContent("支援計画書の作成");
-    expect(headings[8]).toHaveTextContent("モニタリングシートの作成");
-    expect(headings[9]).toHaveTextContent("法令・制度の検索");
-    expect(headings[10]).toHaveTextContent("ログイン許可設定");
-    expect(headings[11]).toHaveTextContent("アカウント管理");
+    expect(headings[7]).toHaveTextContent("相談記録の編集・削除");
+    expect(headings[8]).toHaveTextContent("支援計画書の作成");
+    expect(headings[9]).toHaveTextContent("モニタリングシートの作成");
+    expect(headings[10]).toHaveTextContent("法令・制度の検索");
+    expect(headings[11]).toHaveTextContent("ログイン許可設定");
+    expect(headings[12]).toHaveTextContent("アカウント管理");
   });
 
   it("renders table of contents with anchor links", () => {
     renderHelp();
 
     const tocLinks = screen.getAllByRole("link");
-    expect(tocLinks).toHaveLength(12);
+    expect(tocLinks).toHaveLength(13);
     expect(tocLinks[0]).toHaveAttribute("href", "#dashboard");
     expect(tocLinks[4]).toHaveAttribute("href", "#audio-recording");
     expect(tocLinks[5]).toHaveAttribute("href", "#audio-file-upload");
     expect(tocLinks[6]).toHaveAttribute("href", "#ai-analysis");
-    expect(tocLinks[11]).toHaveAttribute("href", "#settings-accounts");
+    expect(tocLinks[7]).toHaveAttribute("href", "#edit-delete-consultation");
+    expect(tocLinks[12]).toHaveAttribute("href", "#settings-accounts");
   });
 
   it("renders screenshots with lazy loading", () => {
     renderHelp();
 
     const images = screen.getAllByRole("img");
-    expect(images).toHaveLength(12);
+    expect(images).toHaveLength(13);
     images.forEach((img) => {
       expect(img).toHaveAttribute("loading", "lazy");
     });

--- a/frontend/src/pages/Help.tsx
+++ b/frontend/src/pages/Help.tsx
@@ -250,6 +250,35 @@ const HELP_SECTIONS: HelpSection[] = [
     noteImportant: true,
   },
   {
+    id: "edit-delete-consultation",
+    title: "相談記録の編集・削除",
+    description:
+      "記録した相談内容の修正や、誤って作成した記録の削除ができます。",
+    image: { src: "/help/edit-consultation.png", alt: "相談記録の編集・削除" },
+    annotationType: "steps",
+    annotations: [
+      {
+        icon: "1",
+        title: "",
+        description:
+          "相談記録カードの右上にある ⋯ ボタンをクリックします。自分が作成した記録、または管理者権限がある場合に表示されます。",
+      },
+      {
+        icon: "2",
+        title: "",
+        description:
+          "「編集」を選ぶと相談内容がテキストエリアに変わります。内容を修正して「保存」をクリックしてください。",
+      },
+      {
+        icon: "3",
+        title: "",
+        description:
+          "保存後、AIが編集後の内容で自動的に再分析を行います。日時の横に編集者名が表示されます。",
+      },
+    ],
+    note: "削除した記録は画面から消えますが、システム内部には保存されています。誤削除の復旧が必要な場合は管理者にお問い合わせください。",
+  },
+  {
     id: "support-plan",
     title: "支援計画書の作成",
     description:


### PR DESCRIPTION
## Summary
- PR #170-175 で追加した相談記録の編集・削除機能に対するE2Eテストとヘルプページを追加
- E2Eモックルート（PATCH/DELETE）、編集・削除フローテスト2件、ヘルプページに「相談記録の編集・削除」セクション新設
- スクリーンショット生成スクリプトに編集メニュー表示のキャプチャを追加

## Changes (6 files)
- `e2e/helpers.ts`: PATCH/DELETEモックルート追加（mockApiRoutes/mockApiRoutesForHelp両方）、編集済みDEMOデータ追加
- `e2e/case-consultation.spec.ts`: 編集保存・削除フローのE2Eテスト2件追加
- `frontend/src/pages/Help.tsx`: 「相談記録の編集・削除」セクション追加（AI分析結果の後、#8として挿入）
- `e2e/generate-help-screenshots.ts`: 編集メニュースクリーンショット生成追加
- `e2e/help-page.spec.ts`: セクション数アサート 12→13 更新
- `frontend/src/pages/Help.test.tsx`: セクション数アサート 12→13 更新

## Test plan
- [x] BE テスト全パス（230件）
- [x] FE テスト全パス（223件）
- [x] フロントエンドビルド成功
- [x] lint エラーなし
- [ ] `npm run generate:help-screenshots` でedit-consultation.png生成確認
- [ ] E2Eテスト実行（Firebase Auth Emulator + dev server環境で）

Closes #176, #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now edit consultation records; edits trigger automatic re-analysis with editor attribution displayed
  * Users can now delete consultation records directly from the interface

* **Documentation**
  * New help section added with step-by-step instructions and screenshots for editing and deleting consultation records

* **Tests**
  * Comprehensive end-to-end tests added for new edit and delete consultation features

<!-- end of auto-generated comment: release notes by coderabbit.ai -->