### PR TITLE
feat: Firestoreトランザクション化 (#179-#182)

### DIFF
--- a/docs/adr/ADR-006-firestore-transactions.md
+++ b/docs/adr/ADR-006-firestore-transactions.md
@@ -1,0 +1,51 @@
+# ADR-006: Firestoreトランザクション導入方針
+
+## ステータス
+承認済み
+
+## コンテキスト
+MVP段階ではread-then-writeパターン（読み取り → 条件チェック → 書き込み）を使用していたが、並行リクエスト時に以下のリスクがある：
+
+1. **updateCaseStatus**: 2つのリクエストが同時に同じケースのステータスを変更すると、一方の遷移検証が古いデータに基づいて行われ、不正な遷移が発生する可能性
+2. **updateSupportPlan**: 確定済みチェック後・書き込み前に別リクエストが確定を実行すると、確定済み計画が上書きされる
+3. **updateMonitoringSheet**: 同上
+4. **admin PATCH /staff/:id**: 最後のadmin数カウント後・降格書き込み前に別リクエストが同時に降格すると、adminが0人になる可能性
+
+## 決定
+
+### トランザクション化する4箇所
+
+全て `firestore.runTransaction()` でラップし、楽観的同時実行制御を適用する。
+
+| 関数 | ファイル | 保護する不変条件 |
+|------|---------|----------------|
+| `updateCaseStatus` | `case-repository.ts` | ステータス遷移ルールの整合性 |
+| `updateSupportPlan` | `support-plan-repository.ts` | 確定済み計画の不変性 |
+| `updateMonitoringSheet` | `monitoring-repository.ts` | 確定済みシートの不変性 |
+| `PATCH /staff/:id` | `admin-settings.ts` | 最低1人のactiveなadminの維持 |
+
+### トランザクション設計パターン
+
+```typescript
+await firestore.runTransaction(async (tx) => {
+  const doc = await tx.get(ref);         // トランザクション内で読み取り
+  // バリデーション（不変条件チェック）
+  tx.update(ref, updateData);            // トランザクション内で書き込み
+});
+```
+
+### admin PATCH /staff/:id の特殊対応
+
+adminカウントのために全adminドキュメントを取得する必要があるが、Firestoreトランザクションではクエリ結果の各ドキュメントにreadロックがかかる。`limit(2)` で最小限のドキュメントのみ取得し、パフォーマンス影響を抑える。
+
+### トランザクション化しないもの
+
+- `createCase`, `createSupportPlan` 等の作成系: サーバー生成IDのため衝突リスクなし
+- 読み取り専用エンドポイント: 整合性リスクなし
+- `updateConsultation` (編集): editedAt/editedByの記録のみで、不変条件の保護は不要
+
+## 結果
+
+- 並行リクエストによるデータ不整合が防止される
+- Firestoreの楽観的ロックにより、競合時は自動リトライ（最大5回）される
+- パフォーマンスへの影響は最小限（トランザクション内の読み取り数は1-2ドキュメント）

--- a/src/repositories/case-repository.ts
+++ b/src/repositories/case-repository.ts
@@ -45,15 +45,20 @@ export async function listAllCases(status?: CaseStatus): Promise<Case[]> {
 }
 
 export async function updateCaseStatus(id: string, newStatus: CaseStatus): Promise<Case> {
-  const current = await getCase(id);
-  if (!current) throw new Error(`Case ${id} not found`);
+  const docRef = casesRef().doc(id);
 
-  const allowed = VALID_STATUS_TRANSITIONS[current.status];
-  if (!allowed.includes(newStatus)) {
-    throw new Error(`Invalid status transition: ${current.status} → ${newStatus}`);
-  }
+  return firestore.runTransaction(async (tx) => {
+    const doc = await tx.get(docRef);
+    if (!doc.exists) throw new Error(`Case ${id} not found`);
 
-  const now = Timestamp.now();
-  await casesRef().doc(id).update({ status: newStatus, updatedAt: now });
-  return { ...current, status: newStatus, updatedAt: now };
+    const current = { id: doc.id, ...doc.data() } as Case;
+    const allowed = VALID_STATUS_TRANSITIONS[current.status];
+    if (!allowed.includes(newStatus)) {
+      throw new Error(`Invalid status transition: ${current.status} → ${newStatus}`);
+    }
+
+    const now = Timestamp.now();
+    tx.update(docRef, { status: newStatus, updatedAt: now });
+    return { ...current, status: newStatus, updatedAt: now };
+  });
 }

--- a/src/repositories/monitoring-repository.ts
+++ b/src/repositories/monitoring-repository.ts
@@ -44,19 +44,25 @@ export async function updateMonitoringSheet(
   sheetId: string,
   data: Partial<Pick<MonitoringSheet, "overallEvaluation" | "goalEvaluations" | "environmentChanges" | "clientFeedback" | "specialNotes" | "monitoringDate" | "nextMonitoringDate" | "status">>,
 ): Promise<MonitoringSheet> {
-  const current = await getMonitoringSheet(caseId, sheetId);
-  if (!current) throw new Error(`MonitoringSheet ${sheetId} not found`);
-  if (current.status === "confirmed") {
-    throw new Error("Cannot edit a confirmed monitoring sheet");
-  }
+  const docRef = monitoringSheetsRef(caseId).doc(sheetId);
 
-  const now = Timestamp.now();
-  const update: Record<string, unknown> = { ...data, updatedAt: now };
+  return firestore.runTransaction(async (tx) => {
+    const doc = await tx.get(docRef);
+    if (!doc.exists) throw new Error(`MonitoringSheet ${sheetId} not found`);
 
-  if (data.status === "confirmed") {
-    update.confirmedAt = now;
-  }
+    const current = { id: doc.id, caseId, ...doc.data() } as MonitoringSheet;
+    if (current.status === "confirmed") {
+      throw new Error("Cannot edit a confirmed monitoring sheet");
+    }
 
-  await monitoringSheetsRef(caseId).doc(sheetId).update(update);
-  return { ...current, ...update, updatedAt: now } as MonitoringSheet;
+    const now = Timestamp.now();
+    const update: Record<string, unknown> = { ...data, updatedAt: now };
+
+    if (data.status === "confirmed") {
+      update.confirmedAt = now;
+    }
+
+    tx.update(docRef, update);
+    return { ...current, ...update, updatedAt: now } as MonitoringSheet;
+  });
 }

--- a/src/repositories/support-plan-repository.ts
+++ b/src/repositories/support-plan-repository.ts
@@ -44,20 +44,25 @@ export async function updateSupportPlan(
   planId: string,
   data: Partial<Pick<SupportPlan, "overallPolicy" | "goals" | "specialNotes" | "planStartDate" | "nextReviewDate" | "status">>,
 ): Promise<SupportPlan> {
-  const current = await getSupportPlan(caseId, planId);
-  if (!current) throw new Error(`SupportPlan ${planId} not found`);
-  if (current.status === "confirmed") {
-    throw new Error("Cannot edit a confirmed support plan");
-  }
+  const docRef = supportPlansRef(caseId).doc(planId);
 
-  const now = Timestamp.now();
-  const update: Record<string, unknown> = { ...data, updatedAt: now };
+  return firestore.runTransaction(async (tx) => {
+    const doc = await tx.get(docRef);
+    if (!doc.exists) throw new Error(`SupportPlan ${planId} not found`);
 
-  // 確定時にconfirmedAtを設定
-  if (data.status === "confirmed") {
-    update.confirmedAt = now;
-  }
+    const current = { id: doc.id, caseId, ...doc.data() } as SupportPlan;
+    if (current.status === "confirmed") {
+      throw new Error("Cannot edit a confirmed support plan");
+    }
 
-  await supportPlansRef(caseId).doc(planId).update(update);
-  return { ...current, ...update, updatedAt: now } as SupportPlan;
+    const now = Timestamp.now();
+    const update: Record<string, unknown> = { ...data, updatedAt: now };
+
+    if (data.status === "confirmed") {
+      update.confirmedAt = now;
+    }
+
+    tx.update(docRef, update);
+    return { ...current, ...update, updatedAt: now } as SupportPlan;
+  });
 }

--- a/src/routes/admin-settings.ts
+++ b/src/routes/admin-settings.ts
@@ -53,59 +53,77 @@ adminSettingsRouter.patch("/staff/:id", async (req: Request, res: Response) => {
 
   try {
     const staffRef = firestore.collection("staff").doc(id);
-    const staffDoc = await staffRef.get();
-    if (!staffDoc.exists) {
-      res.status(404).json({ error: "Staff not found" });
-      return;
-    }
 
-    // admin自身のロール降格防止
+    // admin自身のロール降格・無効化防止（トランザクション外で早期リターン）
     if (role === "staff" && id === req.user!.staffId) {
       res.status(400).json({ error: "Cannot demote yourself" });
       return;
     }
-
-    // admin自身の無効化防止
     if (disabled === true && id === req.user!.staffId) {
       res.status(400).json({ error: "Cannot disable yourself" });
       return;
     }
 
-    // 最後のadmin降格防止
-    if (role === "staff") {
+    const result = await firestore.runTransaction(async (tx) => {
+      const staffDoc = await tx.get(staffRef);
+      if (!staffDoc.exists) {
+        return { error: "Staff not found", status: 404 } as const;
+      }
+
       const currentData = staffDoc.data()!;
-      if (currentData.role === "admin") {
-        const adminSnapshot = await firestore.collection("staff")
-          .where("role", "==", "admin")
-          .where("disabled", "==", false)
-          .limit(2)
-          .get();
-        const activeAdmins = adminSnapshot.docs.filter(
-          (d) => d.id !== id,
+
+      // 最後のadmin降格防止（トランザクション内で整合性保証）
+      if (role === "staff" && currentData.role === "admin") {
+        const adminSnapshot = await tx.get(
+          firestore.collection("staff")
+            .where("role", "==", "admin")
+            .where("disabled", "==", false)
+            .limit(2),
         );
+        const activeAdmins = adminSnapshot.docs.filter((d) => d.id !== id);
         if (activeAdmins.length === 0) {
-          res.status(400).json({ error: "Cannot demote the last admin" });
-          return;
+          return { error: "Cannot demote the last admin", status: 400 } as const;
         }
       }
-    }
 
-    const updateData: Record<string, unknown> = { updatedAt: new Date() };
-    if (role !== undefined) updateData.role = role;
-    if (disabled !== undefined) updateData.disabled = disabled;
+      // 最後のadmin無効化防止
+      if (disabled === true && currentData.role === "admin") {
+        const adminSnapshot = await tx.get(
+          firestore.collection("staff")
+            .where("role", "==", "admin")
+            .where("disabled", "==", false)
+            .limit(2),
+        );
+        const activeAdmins = adminSnapshot.docs.filter((d) => d.id !== id);
+        if (activeAdmins.length === 0) {
+          return { error: "Cannot disable the last admin", status: 400 } as const;
+        }
+      }
 
-    await staffRef.update(updateData);
+      const updateData: Record<string, unknown> = { updatedAt: new Date() };
+      if (role !== undefined) updateData.role = role;
+      if (disabled !== undefined) updateData.disabled = disabled;
 
-    const existingData = staffDoc.data()!;
-    const merged = { ...existingData, ...updateData };
-    res.json({
-      id,
-      name: (merged.name as string) ?? "",
-      email: (merged.email as string) ?? "",
-      role: (merged.role as string) ?? "staff",
-      disabled: (merged.disabled as boolean) ?? false,
-      createdAt: merged.createdAt ?? null,
+      tx.update(staffRef, updateData);
+
+      const merged = { ...currentData, ...updateData };
+      return {
+        data: {
+          id,
+          name: (merged.name as string) ?? "",
+          email: (merged.email as string) ?? "",
+          role: (merged.role as string) ?? "staff",
+          disabled: (merged.disabled as boolean) ?? false,
+          createdAt: merged.createdAt ?? null,
+        },
+      } as const;
     });
+
+    if ("error" in result) {
+      res.status(result.status as number).json({ error: result.error });
+      return;
+    }
+    res.json(result.data);
   } catch (err) {
     logger.error("Staff update failed", { error: (err as Error).message });
     res.status(500).json({ error: "Internal server error" });

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -12,6 +12,16 @@ vi.mock("./config.js", () => ({
       }),
     }),
     doc: vi.fn(),
+    runTransaction: vi.fn().mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
+      // デフォルトのrunTransaction mock: コールバックにtxオブジェクトを渡して実行
+      const tx = {
+        get: vi.fn(),
+        update: vi.fn(),
+        set: vi.fn(),
+        delete: vi.fn(),
+      };
+      return fn(tx);
+    }),
   },
   generativeModel: {
     generateContent: vi.fn(),
@@ -1510,12 +1520,17 @@ describe("PATCH /api/admin-settings/staff/:id", () => {
   });
 
   it("returns 404 for nonexistent staff", async () => {
+    const mockDocRef = { id: "nonexistent" };
     vi.mocked(firestore.collection).mockReturnValue({
-      doc: vi.fn().mockReturnValue({
-        get: vi.fn().mockResolvedValue({ exists: false }),
-        update: mockUpdate,
-      }),
+      doc: vi.fn().mockReturnValue(mockDocRef),
     } as never);
+    vi.mocked(firestore.runTransaction).mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
+      const tx = {
+        get: vi.fn().mockResolvedValue({ exists: false }),
+        update: vi.fn(),
+      };
+      return fn(tx);
+    });
 
     const res = await request(adminApp).patch("/api/admin-settings/staff/nonexistent").send({ role: "admin" });
     expect(res.status).toBe(404);
@@ -1553,20 +1568,28 @@ describe("PATCH /api/admin-settings/staff/:id", () => {
     const staffData = { name: "唯一の管理者", role: "admin", email: "other@test.com" };
     const adminQueryDocs = [{ id: "other-admin", data: () => ({ role: "admin", disabled: false }) }];
 
-    const mockWhereChain = {
+    const mockDocRef = { id: "other-admin" };
+    const mockQuery = { docs: adminQueryDocs };
+
+    vi.mocked(firestore.collection).mockReturnValue({
+      doc: vi.fn().mockReturnValue(mockDocRef),
       where: vi.fn().mockReturnValue({
-        limit: vi.fn().mockReturnValue({
-          get: vi.fn().mockResolvedValue({ docs: adminQueryDocs }),
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockReturnValue("admin-query"),
         }),
       }),
-    };
-    vi.mocked(firestore.collection).mockReturnValue({
-      doc: vi.fn().mockReturnValue({
-        get: vi.fn().mockResolvedValue({ exists: true, id: "other-admin", data: () => staffData }),
-        update: mockUpdate,
-      }),
-      where: vi.fn().mockReturnValue(mockWhereChain),
     } as never);
+    vi.mocked(firestore.runTransaction).mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
+      const tx = {
+        get: vi.fn()
+          .mockImplementation((ref: unknown) => {
+            if (ref === "admin-query") return Promise.resolve(mockQuery);
+            return Promise.resolve({ exists: true, id: "other-admin", data: () => staffData });
+          }),
+        update: vi.fn(),
+      };
+      return fn(tx);
+    });
 
     const res = await request(adminApp).patch("/api/admin-settings/staff/other-admin").send({ role: "staff" });
     expect(res.status).toBe(400);
@@ -1575,14 +1598,21 @@ describe("PATCH /api/admin-settings/staff/:id", () => {
 
   it("successfully updates role", async () => {
     const staffData = { name: "職員A", email: "a@test.com", role: "staff", disabled: false, createdAt: new Date() };
-    const updatedData = { ...staffData, role: "admin" };
-    const mockGet = vi.fn()
-      .mockResolvedValueOnce({ exists: true, id: "s1", data: () => staffData })
-      .mockResolvedValueOnce({ exists: true, id: "s1", data: () => updatedData });
-    const mockRef = { get: mockGet, update: mockUpdate };
+    const mockDocRef = { id: "s1" };
     vi.mocked(firestore.collection).mockReturnValue({
-      doc: vi.fn().mockReturnValue(mockRef),
+      doc: vi.fn().mockReturnValue(mockDocRef),
     } as never);
+    vi.mocked(firestore.runTransaction).mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
+      const txUpdate = vi.fn();
+      const tx = {
+        get: vi.fn().mockResolvedValue({ exists: true, id: "s1", data: () => staffData }),
+        update: txUpdate,
+      };
+      const result = await fn(tx);
+      mockUpdate.mockReturnValue(undefined);
+      mockUpdate(txUpdate.mock.calls[0]?.[1]);
+      return result;
+    });
 
     const res = await request(adminApp).patch("/api/admin-settings/staff/s1").send({ role: "admin" });
     expect(res.status).toBe(200);
@@ -1592,14 +1622,21 @@ describe("PATCH /api/admin-settings/staff/:id", () => {
 
   it("successfully toggles disabled", async () => {
     const staffData = { name: "職員A", email: "a@test.com", role: "staff", disabled: false, createdAt: new Date() };
-    const updatedData = { ...staffData, disabled: true };
-    const mockGet = vi.fn()
-      .mockResolvedValueOnce({ exists: true, id: "s1", data: () => staffData })
-      .mockResolvedValueOnce({ exists: true, id: "s1", data: () => updatedData });
-    const mockRef = { get: mockGet, update: mockUpdate };
+    const mockDocRef = { id: "s1" };
     vi.mocked(firestore.collection).mockReturnValue({
-      doc: vi.fn().mockReturnValue(mockRef),
+      doc: vi.fn().mockReturnValue(mockDocRef),
     } as never);
+    vi.mocked(firestore.runTransaction).mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
+      const txUpdate = vi.fn();
+      const tx = {
+        get: vi.fn().mockResolvedValue({ exists: true, id: "s1", data: () => staffData }),
+        update: txUpdate,
+      };
+      const result = await fn(tx);
+      mockUpdate.mockReturnValue(undefined);
+      mockUpdate(txUpdate.mock.calls[0]?.[1]);
+      return result;
+    });
 
     const res = await request(adminApp).patch("/api/admin-settings/staff/s1").send({ disabled: true });
     expect(res.status).toBe(200);

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -13,15 +13,9 @@ vi.mock("./config.js", () => ({
     }),
     doc: vi.fn(),
     runTransaction: vi.fn().mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
-      // デフォルトのrunTransaction mock: コールバックにtxオブジェクトを渡して実行
-      const tx = {
-        get: vi.fn(),
-        update: vi.fn(),
-        set: vi.fn(),
-        delete: vi.fn(),
-      };
+      const tx = { get: vi.fn(), update: vi.fn(), set: vi.fn(), delete: vi.fn() };
       return fn(tx);
-    }),
+    }) as never,
   },
   generativeModel: {
     generateContent: vi.fn(),
@@ -1524,7 +1518,8 @@ describe("PATCH /api/admin-settings/staff/:id", () => {
     vi.mocked(firestore.collection).mockReturnValue({
       doc: vi.fn().mockReturnValue(mockDocRef),
     } as never);
-    vi.mocked(firestore.runTransaction).mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (firestore.runTransaction as any).mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
       const tx = {
         get: vi.fn().mockResolvedValue({ exists: false }),
         update: vi.fn(),
@@ -1579,7 +1574,8 @@ describe("PATCH /api/admin-settings/staff/:id", () => {
         }),
       }),
     } as never);
-    vi.mocked(firestore.runTransaction).mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (firestore.runTransaction as any).mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
       const tx = {
         get: vi.fn()
           .mockImplementation((ref: unknown) => {
@@ -1596,13 +1592,47 @@ describe("PATCH /api/admin-settings/staff/:id", () => {
     expect(res.body.error).toBe("Cannot demote the last admin");
   });
 
+  it("prevents disabling the last admin", async () => {
+    const staffData = { name: "唯一の管理者", role: "admin", email: "other@test.com", disabled: false };
+    const adminQueryDocs = [{ id: "other-admin", data: () => ({ role: "admin", disabled: false }) }];
+
+    const mockDocRef = { id: "other-admin" };
+    const mockQuery = { docs: adminQueryDocs };
+
+    vi.mocked(firestore.collection).mockReturnValue({
+      doc: vi.fn().mockReturnValue(mockDocRef),
+      where: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockReturnValue("admin-query"),
+        }),
+      }),
+    } as never);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (firestore.runTransaction as any).mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
+      const tx = {
+        get: vi.fn()
+          .mockImplementation((ref: unknown) => {
+            if (ref === "admin-query") return Promise.resolve(mockQuery);
+            return Promise.resolve({ exists: true, id: "other-admin", data: () => staffData });
+          }),
+        update: vi.fn(),
+      };
+      return fn(tx);
+    });
+
+    const res = await request(adminApp).patch("/api/admin-settings/staff/other-admin").send({ disabled: true });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("Cannot disable the last admin");
+  });
+
   it("successfully updates role", async () => {
     const staffData = { name: "職員A", email: "a@test.com", role: "staff", disabled: false, createdAt: new Date() };
     const mockDocRef = { id: "s1" };
     vi.mocked(firestore.collection).mockReturnValue({
       doc: vi.fn().mockReturnValue(mockDocRef),
     } as never);
-    vi.mocked(firestore.runTransaction).mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (firestore.runTransaction as any).mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
       const txUpdate = vi.fn();
       const tx = {
         get: vi.fn().mockResolvedValue({ exists: true, id: "s1", data: () => staffData }),
@@ -1626,7 +1656,8 @@ describe("PATCH /api/admin-settings/staff/:id", () => {
     vi.mocked(firestore.collection).mockReturnValue({
       doc: vi.fn().mockReturnValue(mockDocRef),
     } as never);
-    vi.mocked(firestore.runTransaction).mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (firestore.runTransaction as any).mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
       const txUpdate = vi.fn();
       const tx = {
         get: vi.fn().mockResolvedValue({ exists: true, id: "s1", data: () => staffData }),


### PR DESCRIPTION
## Summary
- `updateCaseStatus`, `updateSupportPlan`, `updateMonitoringSheet`, `admin PATCH /staff/:id` を `runTransaction()` でラップ
- 並行リクエストによるステータス不整合・確定済み上書き・最後のadmin消失を防止
- admin PATCHで最後のadmin無効化防止も追加
- ADR-006として設計判断を記録

## Test plan
- [x] 既存テスト230件全パス
- [x] TypeScriptビルド成功
- [ ] Firestore Emulatorでの同時実行テスト（本番デプロイ前に手動検証）

Closes #179, Closes #180, Closes #181, Closes #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added architectural decision record documenting Firestore transaction adoption policy and design patterns.

* **Refactor**
  * Implemented atomic transactions for case status, monitoring sheet, support plan, and staff role updates to ensure data consistency and prevent concurrent inconsistencies.

* **Tests**
  * Updated test coverage for transaction-based update flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->