### PR TITLE
feat: Secret Manager移行 + Firestoreバックアップ設定 (#183, #185)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -73,5 +73,6 @@ jobs:
             --min-instances=0 \
             --max-instances=3 \
             --set-env-vars="^::^GCP_PROJECT_ID=${{ env.PROJECT_ID }}::GCP_REGION=${{ env.REGION }}::ALLOWED_EMAIL_DOMAINS=osaka-fujinhome.or.jp::ALLOWED_EMAILS=hy.unimail.11@gmail.com" \
+            --set-secrets="AI_RETRY_SECRET=ai-retry-secret:latest" \
             --service-account=kyugo-ai-deployer@kyugo-ai-dev.iam.gserviceaccount.com \
             --quiet

--- a/docs/operations/backup.md
+++ b/docs/operations/backup.md
@@ -1,0 +1,84 @@
+# Firestoreバックアップ運用手順
+
+## 概要
+
+Firestore Native Modeの自動バックアップを日次で実行し、7日間保持する。
+
+## 設定
+
+| 項目 | 値 |
+|------|-----|
+| データベース | `(default)` |
+| リージョン | `asia-northeast1` |
+| 頻度 | 日次（daily） |
+| 保持期間 | 7日間 |
+| プロジェクト | `kyugo-ai-dev` |
+
+## バックアップの確認
+
+```bash
+# スケジュール確認
+gcloud firestore backups schedules list \
+  --database='(default)' \
+  --project=kyugo-ai-dev
+
+# バックアップ一覧確認
+gcloud firestore backups list \
+  --project=kyugo-ai-dev
+```
+
+## リストア手順
+
+### 1. バックアップの確認
+
+```bash
+gcloud firestore backups list --project=kyugo-ai-dev
+```
+
+出力例:
+```
+NAME                                                                          STATE  DATABASE
+projects/kyugo-ai-dev/locations/asia-northeast1/backups/2026-03-21T00:00:00Z  READY  (default)
+```
+
+### 2. 新しいデータベースへのリストア
+
+Firestoreのリストアは既存データベースへの上書きではなく、新しいデータベースとして復元される。
+
+```bash
+gcloud firestore databases restore \
+  --source-backup=projects/kyugo-ai-dev/locations/asia-northeast1/backups/<BACKUP_NAME> \
+  --destination-database=restored-db \
+  --project=kyugo-ai-dev
+```
+
+### 3. データ検証
+
+リストアされたデータベースの内容を確認し、問題なければアプリケーションの接続先を切り替える。
+
+### 4. 接続先切り替え
+
+Cloud Runの環境変数`FIRESTORE_DATABASE_ID`を`restored-db`に変更するか、データを元のデータベースにコピーする。
+
+## スケジュールの変更
+
+```bash
+# スケジュール削除
+gcloud firestore backups schedules delete <SCHEDULE_ID> \
+  --database='(default)' \
+  --project=kyugo-ai-dev
+
+# 新スケジュール作成（例: 14日保持）
+gcloud firestore backups schedules create \
+  --database='(default)' \
+  --recurrence=daily \
+  --retention=14d \
+  --project=kyugo-ai-dev
+```
+
+## 注意事項
+
+- バックアップはFirestoreのマネージド機能で自動実行される（Cloud Schedulerは不要）
+- バックアップの保存先リージョンはデータベースと同じ`asia-northeast1`
+- リストアは**新しいデータベースへの復元のみ**対応（既存DBへの上書きは不可）
+- バックアップ保持期間を超えたバックアップは自動削除される


### PR DESCRIPTION
## Summary
- AI_RETRY_SECRET を GCP Secret Manager へ移行（`--set-secrets` でCloud Runに注入）
- Firestore日次バックアップスケジュール作成（7日保持）
- `docs/operations/backup.md` にリストア手順を記載

## GCPリソース変更
- Secret Manager API 有効化
- `ai-retry-secret` シークレット作成（asia-northeast1レプリケーション）
- デプロイSAに `roles/secretmanager.secretAccessor` 付与
- Firestoreバックアップスケジュール（daily/7d retention）作成

## Test plan
- [x] BE 231テスト全パス
- [x] ビルド成功
- [ ] 次回CDデプロイ時にSecret Manager注入を確認

Closes #183, Closes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)