### PR TITLE
feat: CSVエクスポート - ケース一覧・相談記録 (#190, #191)

### DIFF
--- a/frontend/src/pages/CaseDetail.tsx
+++ b/frontend/src/pages/CaseDetail.tsx
@@ -192,9 +192,29 @@ export function CaseDetail() {
             <>
             <div className="section-header">
               <h3>相談記録</h3>
-              <button className="btn btn-accent" onClick={() => setShowNewConsultation(true)}>
-                ＋ 新規相談記録
-              </button>
+              <div style={{ display: "flex", gap: "0.5rem" }}>
+                <button
+                  className="btn btn-outline btn-sm"
+                  onClick={async () => {
+                    try {
+                      const res = await api.get(`/api/cases/${id}/consultations/export/csv`);
+                      const blob = new Blob([res.data], { type: "text/csv; charset=utf-8" });
+                      const url = URL.createObjectURL(blob);
+                      const a = document.createElement("a");
+                      a.href = url;
+                      a.download = `consultations_${id}_${new Date().toISOString().slice(0, 10)}.csv`;
+                      a.click();
+                      URL.revokeObjectURL(url);
+                    } catch { /* ignore */ }
+                  }}
+                  disabled={consultations.length === 0}
+                >
+                  CSV出力
+                </button>
+                <button className="btn btn-accent" onClick={() => setShowNewConsultation(true)}>
+                  ＋ 新規相談記録
+                </button>
+              </div>
             </div>
 
             {consultations.length === 0 ? (

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -70,9 +70,29 @@ export function Dashboard() {
 
         <div className="section-header">
           <h3>全ケース</h3>
-          <button className="btn btn-accent" onClick={() => setShowNewCase(true)}>
-            ＋ 新規ケース
-          </button>
+          <div style={{ display: "flex", gap: "0.5rem" }}>
+            <button
+              className="btn btn-outline btn-sm"
+              onClick={async () => {
+                try {
+                  const res = await api.get("/api/cases/export/csv");
+                  const blob = new Blob([res.data], { type: "text/csv; charset=utf-8" });
+                  const url = URL.createObjectURL(blob);
+                  const a = document.createElement("a");
+                  a.href = url;
+                  a.download = `cases_${new Date().toISOString().slice(0, 10)}.csv`;
+                  a.click();
+                  URL.revokeObjectURL(url);
+                } catch { /* ignore */ }
+              }}
+              disabled={cases.length === 0}
+            >
+              CSV出力
+            </button>
+            <button className="btn btn-accent" onClick={() => setShowNewCase(true)}>
+              ＋ 新規ケース
+            </button>
+          </div>
         </div>
 
         {loading ? (

--- a/src/routes/cases.ts
+++ b/src/routes/cases.ts
@@ -11,6 +11,9 @@ import { supportPlansRouter } from "./support-plans.js";
 import { monitoringRouter } from "./monitoring.js";
 import { legalSearchRouter } from "./legal-search.js";
 import { paramStr, validate } from "./utils.js";
+import { toCsv, CsvColumn } from "../utils/csv.js";
+import { Case } from "../types.js";
+import { logger } from "../utils/logger.js";
 
 export const casesRouter = Router();
 
@@ -25,6 +28,52 @@ casesRouter.use("/:id/monitoring", monitoringRouter);
 
 // 法令検索ルートを委譲
 casesRouter.use("/:id/legal-search", legalSearchRouter);
+
+// Timestamp を文字列に変換（CSV用）
+function formatTimestamp(ts: unknown): string {
+  if (!ts) return "";
+  if (typeof ts === "object" && ts !== null && "toDate" in ts) {
+    return (ts as Timestamp).toDate().toISOString();
+  }
+  return String(ts);
+}
+
+const STATUS_LABELS: Record<string, string> = {
+  active: "対応中",
+  referred: "紹介済",
+  closed: "終了",
+};
+
+const CASE_CSV_COLUMNS: CsvColumn<Case>[] = [
+  { header: "ケースID", value: (c) => c.id },
+  { header: "相談者名", value: (c) => c.clientName },
+  { header: "相談者ID", value: (c) => c.clientId },
+  { header: "生年月日", value: (c) => formatTimestamp(c.dateOfBirth) },
+  { header: "ステータス", value: (c) => STATUS_LABELS[c.status] ?? c.status },
+  { header: "担当職員ID", value: (c) => c.assignedStaffId },
+  { header: "作成日時", value: (c) => formatTimestamp(c.createdAt) },
+  { header: "更新日時", value: (c) => formatTimestamp(c.updatedAt) },
+];
+
+// GET /api/cases/export/csv - ケース一覧CSVエクスポート
+casesRouter.get("/export/csv", async (req: Request, res: Response) => {
+  try {
+    const user = req.user!;
+    const cases = user.role === "admin"
+      ? await caseRepo.listAllCases()
+      : await caseRepo.listCasesByStaff(user.staffId);
+
+    const csv = toCsv(CASE_CSV_COLUMNS, cases);
+    const filename = `cases_${new Date().toISOString().slice(0, 10)}.csv`;
+
+    res.setHeader("Content-Type", "text/csv; charset=utf-8");
+    res.setHeader("Content-Disposition", `attachment; filename="${filename}"`);
+    res.send(csv);
+  } catch (err) {
+    logger.error("CSV export failed", { error: (err as Error).message });
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
 
 // POST /api/cases - ケース作成（assignedStaffIdはreq.userから強制）
 casesRouter.post("/", async (req: Request, res: Response) => {

--- a/src/routes/consultations.ts
+++ b/src/routes/consultations.ts
@@ -17,6 +17,7 @@ import {
 } from "../schemas/case.js";
 import { paramStr, validate } from "./utils.js";
 import type { Consultation } from "../types.js";
+import { toCsv, CsvColumn } from "../utils/csv.js";
 
 // PATCH/DELETE 共通: 相談記録の存在確認＋作成者 OR admin 権限チェック
 async function requireConsultationOwnership(
@@ -172,6 +173,48 @@ consultationsRouter.post("/audio", requireCaseAccess, aiLimiter, upload.single("
       logger.error("Audio consultation creation failed", { error: message });
       res.status(500).json({ error: "Internal server error" });
     }
+  }
+});
+
+// Timestamp を文字列に変換（CSV用）
+function formatTimestamp(ts: unknown): string {
+  if (!ts) return "";
+  if (typeof ts === "object" && ts !== null && "toDate" in ts) {
+    return (ts as Timestamp).toDate().toISOString();
+  }
+  return String(ts);
+}
+
+const CONSULTATION_TYPE_LABELS: Record<string, string> = {
+  visit: "訪問", counter: "窓口", phone: "電話", online: "オンライン",
+};
+
+const CONSULTATION_CSV_COLUMNS: CsvColumn<Consultation>[] = [
+  { header: "相談ID", value: (c) => c.id },
+  { header: "ケースID", value: (c) => c.caseId },
+  { header: "担当職員ID", value: (c) => c.staffId },
+  { header: "相談種別", value: (c) => CONSULTATION_TYPE_LABELS[c.consultationType] ?? c.consultationType },
+  { header: "相談内容", value: (c) => c.content },
+  { header: "AI要約", value: (c) => c.summary },
+  { header: "AI状態", value: (c) => c.aiStatus },
+  { header: "作成日時", value: (c) => formatTimestamp(c.createdAt) },
+];
+
+// GET /api/cases/:id/consultations/export/csv - 相談記録CSVエクスポート
+consultationsRouter.get("/export/csv", requireCaseAccess, async (req: Request, res: Response) => {
+  try {
+    const caseId = paramStr(req.params.id);
+    const consultations = await consultationRepo.listConsultations(caseId);
+
+    const csv = toCsv(CONSULTATION_CSV_COLUMNS, consultations);
+    const filename = `consultations_${caseId}_${new Date().toISOString().slice(0, 10)}.csv`;
+
+    res.setHeader("Content-Type", "text/csv; charset=utf-8");
+    res.setHeader("Content-Disposition", `attachment; filename="${filename}"`);
+    res.send(csv);
+  } catch (err) {
+    logger.error("Consultation CSV export failed", { error: (err as Error).message });
+    res.status(500).json({ error: "Internal server error" });
   }
 });
 

--- a/src/utils/csv.test.ts
+++ b/src/utils/csv.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { toCsv } from "./csv.js";
+
+describe("toCsv", () => {
+  it("generates CSV with BOM and headers", () => {
+    const columns = [
+      { header: "名前", value: (r: { name: string }) => r.name },
+      { header: "年齢", value: (r: { age: number }) => r.age },
+    ];
+    const rows = [{ name: "田中太郎", age: 30 }];
+    const csv = toCsv(columns, rows);
+
+    expect(csv).toContain("\uFEFF"); // BOM
+    expect(csv).toContain("名前,年齢\r\n");
+    expect(csv).toContain("田中太郎,30\r\n");
+  });
+
+  it("escapes cells with commas", () => {
+    const columns = [{ header: "値", value: (r: { v: string }) => r.v }];
+    const csv = toCsv(columns, [{ v: "a,b" }]);
+    expect(csv).toContain('"a,b"');
+  });
+
+  it("escapes cells with double quotes", () => {
+    const columns = [{ header: "値", value: (r: { v: string }) => r.v }];
+    const csv = toCsv(columns, [{ v: 'say "hello"' }]);
+    expect(csv).toContain('"say ""hello"""');
+  });
+
+  it("handles null and undefined", () => {
+    const columns = [{ header: "値", value: () => null }];
+    const csv = toCsv(columns, [{}]);
+    expect(csv).toContain("値\r\n\r\n");
+  });
+
+  it("handles empty rows", () => {
+    const columns = [{ header: "A", value: (r: { a: string }) => r.a }];
+    const csv = toCsv(columns, []);
+    expect(csv).toBe("\uFEFFA\r\n");
+  });
+});

--- a/src/utils/csv.ts
+++ b/src/utils/csv.ts
@@ -1,0 +1,29 @@
+/**
+ * CSVエクスポートユーティリティ
+ * BOM付きUTF-8でExcel互換のCSVを生成する。
+ */
+
+const BOM = "\uFEFF";
+
+function escapeCell(value: unknown): string {
+  if (value === null || value === undefined) return "";
+  const str = String(value);
+  // カンマ、改行、ダブルクォートを含む場合はクォート
+  if (str.includes(",") || str.includes("\n") || str.includes('"')) {
+    return '"' + str.replace(/"/g, '""') + '"';
+  }
+  return str;
+}
+
+export interface CsvColumn<T> {
+  header: string;
+  value: (row: T) => unknown;
+}
+
+export function toCsv<T>(columns: CsvColumn<T>[], rows: T[]): string {
+  const headerLine = columns.map((c) => escapeCell(c.header)).join(",");
+  const dataLines = rows.map((row) =>
+    columns.map((c) => escapeCell(c.value(row))).join(","),
+  );
+  return BOM + [headerLine, ...dataLines].join("\r\n") + "\r\n";
+}


### PR DESCRIPTION
## Summary
- `src/utils/csv.ts`: BOM付きUTF-8のCSVユーティリティ（Excel互換）+ テスト5件
- `GET /api/cases/export/csv`: ケース一覧CSVエクスポート（admin全件/staff担当分）
- `GET /api/cases/:id/consultations/export/csv`: 相談記録CSVエクスポート
- Dashboard・CaseDetailに「CSV出力」ボタン追加

## Test plan
- [x] BE 241テスト全パス（csv.ts 5件含む）
- [x] FE 231テスト全パス
- [x] ビルド成功

Closes #190, Closes #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)