### PR TITLE
feat: Aboutページスクリーンショット拡大表示（ライトボックス）

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1784,6 +1784,85 @@ a:hover { color: var(--ai-600); }
   line-height: 1.7;
 }
 
+/* ── Screenshot Image as Button ── */
+
+button.about-screenshot-image {
+  display: block;
+  width: 100%;
+  border: none;
+  padding: 0;
+  cursor: zoom-in;
+  position: relative;
+}
+
+.about-screenshot-zoom-hint {
+  position: absolute;
+  bottom: var(--space-3);
+  right: var(--space-3);
+  background: rgba(0, 0, 0, 0.6);
+  color: white;
+  font-size: var(--text-xs);
+  padding: var(--space-1) var(--space-3);
+  border-radius: var(--radius-sm);
+  opacity: 0;
+  transition: opacity var(--duration-fast) var(--ease-out);
+  pointer-events: none;
+}
+
+button.about-screenshot-image:hover .about-screenshot-zoom-hint {
+  opacity: 1;
+}
+
+/* ── Lightbox ── */
+
+.lightbox-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  background: rgba(0, 0, 0, 0.85);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: zoom-out;
+  animation: lightboxFadeIn 0.2s ease-out;
+}
+
+@keyframes lightboxFadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.lightbox-close {
+  position: absolute;
+  top: var(--space-4);
+  right: var(--space-4);
+  background: rgba(255, 255, 255, 0.15);
+  border: none;
+  color: white;
+  font-size: var(--text-xl);
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background var(--duration-fast) var(--ease-out);
+}
+
+.lightbox-close:hover {
+  background: rgba(255, 255, 255, 0.3);
+}
+
+.lightbox-image {
+  max-width: 90vw;
+  max-height: 90vh;
+  object-fit: contain;
+  border-radius: var(--radius-md);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+  cursor: default;
+}
+
 /* ── Security ── */
 
 .about-security-section {

--- a/frontend/src/pages/About.tsx
+++ b/frontend/src/pages/About.tsx
@@ -1,3 +1,4 @@
+import { useState, useCallback, useEffect } from "react";
 import { useNavigate, Link } from "react-router-dom";
 
 interface ContentItem {
@@ -140,12 +141,13 @@ function SecurityCard({ point }: { point: ContentItem }) {
   );
 }
 
-function ScreenshotCard({ item, index }: { item: Screenshot; index: number }) {
+function ScreenshotCard({ item, index, onOpen }: { item: Screenshot; index: number; onOpen: () => void }) {
   return (
     <div className="about-screenshot-card">
-      <div className="about-screenshot-image">
+      <button type="button" className="about-screenshot-image" onClick={onOpen} aria-label={`${item.title}の画像を拡大表示`}>
         <img src={item.src} alt={item.alt} loading={index === 0 ? "eager" : "lazy"} />
-      </div>
+        <div className="about-screenshot-zoom-hint" aria-hidden="true">クリックで拡大</div>
+      </button>
       <div className="about-screenshot-body">
         <h3>{item.title}</h3>
         <p>{item.description}</p>
@@ -154,12 +156,30 @@ function ScreenshotCard({ item, index }: { item: Screenshot; index: number }) {
   );
 }
 
+function Lightbox({ src, alt, onClose }: { src: string; alt: string; onClose: () => void }) {
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => { if (e.key === "Escape") onClose(); };
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [onClose]);
+
+  return (
+    <div className="lightbox-overlay" role="dialog" aria-modal="true" aria-label={alt} onClick={onClose}>
+      <button type="button" className="lightbox-close" onClick={onClose} aria-label="閉じる">✕</button>
+      <img src={src} alt={alt} className="lightbox-image" onClick={(e) => e.stopPropagation()} />
+    </div>
+  );
+}
+
 export function About() {
   const navigate = useNavigate();
   const goToLogin = () => navigate("/login");
+  const [lightboxImage, setLightboxImage] = useState<{ src: string; alt: string } | null>(null);
+  const closeLightbox = useCallback(() => setLightboxImage(null), []);
 
   return (
     <div className="about-page">
+      {lightboxImage && <Lightbox src={lightboxImage.src} alt={lightboxImage.alt} onClose={closeLightbox} />}
       {/* ── Navigation Bar ── */}
       <nav className="about-nav">
         <div className="about-nav-inner">
@@ -224,7 +244,7 @@ export function About() {
           </div>
           <div className="about-screenshots-grid">
             {SCREENSHOTS.map((s, i) => (
-              <ScreenshotCard key={s.title} item={s} index={i} />
+              <ScreenshotCard key={s.title} item={s} index={i} onOpen={() => setLightboxImage({ src: s.src, alt: s.alt })} />
             ))}
           </div>
         </div>


### PR DESCRIPTION
## Summary
Aboutページの「実際の操作画面をご覧ください」セクションのスクリーンショットをクリックで拡大表示できるライトボックスを追加。

- 画像クリックでフルスクリーンポップアップ
- Escキーまたは背景クリックで閉じる
- ホバー時に「クリックで拡大」ヒント表示
- アクセシビリティ対応（role=dialog, aria-modal, aria-label）

## Test plan
- [x] About.test.tsx 11件全パス
- [x] FEビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)