### PR TITLE
feat: 音声文字起こしを折りたたみ表示に変更

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -543,7 +543,13 @@ a:hover { color: var(--ai-600); }
 .transcript-label {
   font-size: var(--text-xs); font-weight: 700;
   color: var(--text-tertiary); margin-bottom: var(--space-2);
+  display: flex; align-items: center; justify-content: space-between;
 }
+.transcript-toggle {
+  background: none; border: none; cursor: pointer;
+  font-size: var(--text-xs); color: var(--ai-500); padding: 0;
+}
+.transcript-toggle:hover { text-decoration: underline; }
 
 /* ═══════════════════════════════════════
    AI Results Panel
@@ -915,8 +921,19 @@ a:hover { color: var(--ai-600); }
 .transcript-block {
   background: var(--bg-surface); border: 1px solid var(--border-light);
   border-radius: var(--radius-sm); padding: var(--space-4);
-  font-size: var(--text-sm); line-height: 2; color: var(--text-primary);
-  max-height: 240px; overflow-y: auto; white-space: pre-wrap;
+  font-size: var(--text-sm); line-height: 1.8; color: var(--text-primary);
+  white-space: pre-wrap; transition: max-height var(--duration-normal) var(--ease-out);
+}
+.transcript-block.collapsed {
+  max-height: 5.4em; overflow: hidden;
+  position: relative;
+}
+.transcript-block.collapsed::after {
+  content: ""; position: absolute; bottom: 0; left: 0; right: 0;
+  height: 2em; background: linear-gradient(transparent, var(--bg-surface));
+}
+.transcript-block.expanded {
+  max-height: none; overflow-y: auto;
 }
 
 /* 相談記録 編集・削除 */

--- a/frontend/src/pages/CaseDetail.tsx
+++ b/frontend/src/pages/CaseDetail.tsx
@@ -30,6 +30,7 @@ export function CaseDetail() {
   const [editTranscript, setEditTranscript] = useState("");
   const [editSaving, setEditSaving] = useState(false);
   const [menuOpenId, setMenuOpenId] = useState<string | null>(null);
+  const [expandedTranscripts, setExpandedTranscripts] = useState<Set<string>>(new Set());
 
   const loadData = useCallback(async () => {
     if (!id) return;
@@ -345,8 +346,23 @@ export function CaseDetail() {
 
                             {con.transcript && (
                               <div className="transcript-section">
-                                <div className="transcript-label">文字起こし</div>
-                                <div className="transcript-block">{con.transcript}</div>
+                                <div className="transcript-label">
+                                  🎙️ 音声から文字起こし
+                                  <button
+                                    className="transcript-toggle"
+                                    onClick={() => setExpandedTranscripts(prev => {
+                                      const next = new Set(prev);
+                                      if (next.has(con.id)) next.delete(con.id);
+                                      else next.add(con.id);
+                                      return next;
+                                    })}
+                                  >
+                                    {expandedTranscripts.has(con.id) ? "折りたたむ ▲" : "全文を表示 ▼"}
+                                  </button>
+                                </div>
+                                <div className={`transcript-block ${expandedTranscripts.has(con.id) ? "expanded" : "collapsed"}`}>
+                                  {con.transcript}
+                                </div>
                               </div>
                             )}
                           </>


### PR DESCRIPTION
## Summary
- 音声相談記録の文字起こしをデフォルト3行truncate + トグル展開に変更
- AI分析パネルの視認性を向上（文字起こしが画面を占有しなくなる）
- ラベルを「🎙️ 音声から文字起こし」に変更（テキスト相談と視覚的に区別）

Closes #220

## Test plan
- [x] BE build パス
- [x] FE build パス
- [ ] 本番デプロイ後、音声相談記録の折りたたみ表示を確認

## Quality gate
- [ ] `/simplify` 実施済み（3ファイル未満の場合はN/A）
- [ ] `/safe-refactor` 実施済み（3ファイル未満の場合はN/A）

🤖 Generated with [Claude Code](https://claude.com/claude-code)